### PR TITLE
ページの初回読み込み時に1回だけクエリが発行されるようにする

### DIFF
--- a/front/src/router/RouteRenderer.tsx
+++ b/front/src/router/RouteRenderer.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
-import { useRelayEnvironment } from "react-relay";
 import { SwitchProps } from "react-router";
 
 import { RouteConfig, renderRoutes } from "./renderRoutes";
@@ -16,6 +15,5 @@ export const RouteRenderer: React.FC<Props> = ({
   extraProps,
   switchProps,
 }) => {
-  const environment = useRelayEnvironment();
-  return renderRoutes(routes, environment, extraProps, switchProps);
+  return renderRoutes(routes, extraProps, switchProps);
 };

--- a/front/src/router/renderRoutes.tsx
+++ b/front/src/router/renderRoutes.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Environment } from "react-relay";
+import React, { useState } from "react";
+import { Environment, useRelayEnvironment } from "react-relay";
 import { SwitchProps } from "react-router";
 import {
   RouteConfig as OriginalRouteConfig,
@@ -32,7 +32,6 @@ export interface RouteConfig extends Omit<OriginalRouteConfig, "component"> {
 
 export const renderRoutes = (
   routes: RouteConfig[] | undefined,
-  environment: Environment,
   extraProps?: any,
   switchProps?: SwitchProps
 ): React.ReactElement | null => {
@@ -44,26 +43,32 @@ export const renderRoutes = (
           path={route.path}
           exact={route.exact}
           strict={route.strict}
-          render={(props) => {
-            if (!route.component) {
-              return null;
-            }
-
-            const params = props.match.params;
-            const prepared = route.prepare
-              ? route.prepare({ params, environment })
-              : null;
-            return (
-              <route.component
-                {...props}
-                {...extraProps}
-                prepared={prepared}
-                route={route}
-              />
-            );
-          }}
+          render={(props) => (
+            <WrappedRouteComponent {...props} route={route} {...extraProps} />
+          )}
         />
       ))}
     </Switch>
   ) : null;
+};
+
+const WrappedRouteComponent: React.VFC<RouteConfigComponentProps<any>> = (
+  props
+) => {
+  const { route, match } = props;
+  const { params } = match;
+  const environment = useRelayEnvironment();
+
+  const [prepared] = useState(() => {
+    if (!route?.prepare) {
+      return null;
+    }
+    return route.prepare({ params, environment });
+  });
+
+  if (!(route && route.component)) {
+    return null;
+  }
+
+  return <route.component {...props} prepared={prepared} />;
 };


### PR DESCRIPTION
close #35
読み込み中に前のページを被せる処理のために、ページ遷移時には2回クエリが叩かれているけど、それはなんか別のところでがんばろう。

preloadムズい