### PR TITLE
Revert "ページの初回読み込み時に1回だけクエリが発行されるようにする"

### DIFF
--- a/front/src/router/RouteRenderer.tsx
+++ b/front/src/router/RouteRenderer.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
+import { useRelayEnvironment } from "react-relay";
 import { SwitchProps } from "react-router";
 
 import { RouteConfig, renderRoutes } from "./renderRoutes";
@@ -15,5 +16,6 @@ export const RouteRenderer: React.FC<Props> = ({
   extraProps,
   switchProps,
 }) => {
-  return renderRoutes(routes, extraProps, switchProps);
+  const environment = useRelayEnvironment();
+  return renderRoutes(routes, environment, extraProps, switchProps);
 };


### PR DESCRIPTION
Reverts kmc-jp/GodUploader-graphql#37

作品詳細ページで前後の作品へのリンクをクリックしてもページが読み込まれなくなっていたので戻す