### PR TITLE
画像を追加するボタンっぽくする

### DIFF
--- a/front/src/pages/UploadArtwork.tsx
+++ b/front/src/pages/UploadArtwork.tsx
@@ -104,19 +104,20 @@ const UploadArtworkForm = () => {
       <div className="panel-body px-4 py-4">
         <form onSubmit={handleSubmit}>
           <div className="mb-3">
-            <label htmlFor="file" className="form-label">
+            <p>
               アップロードする画像を追加{" "}
               <span className="text-danger">
                 (GIF/JPEG/PNG形式, 合計{MAX_FILESIZE_MB}MBまで,
                 先頭の画像がサムネイルになります)
               </span>
-            </label>
+            </p>
             <input
               type="file"
               className="form-control"
               id="file"
               multiple
               accept="image/gif,image/png,image/jpeg"
+              style={{ display: "none" }}
               onChange={handleFileChange}
             />
             {filesizeLimitExceeded && (
@@ -124,8 +125,8 @@ const UploadArtworkForm = () => {
                 アップロードするファイルのサイズが大きすぎます
               </div>
             )}
-            {images.length > 0 && (
-              <div className="d-flex mt-2">
+            <div className="d-flex mt-2">
+              {images.length > 0 && (
                 <DndContext
                   sensors={sensors}
                   collisionDetection={closestCenter}
@@ -145,8 +146,23 @@ const UploadArtworkForm = () => {
                     ))}
                   </SortableContext>
                 </DndContext>
-              </div>
-            )}
+              )}
+              <label
+                htmlFor="file"
+                title="ここをタップして画像を追加"
+                className="form-label card"
+                style={{
+                  width: 186,
+                  height: 186,
+                  cursor: "pointer",
+                }}
+              >
+                <i
+                  className="bi bi-plus-lg mx-auto my-auto"
+                  style={{ fontSize: "2em" }}
+                ></i>
+              </label>
+            </div>
           </div>
           <div className="mb-3">
             <TitleInput />


### PR DESCRIPTION
#72

`<input type="file">` 要素は画像の追加にのみ使うことにしていたけど、元のUIと、画像をドラッグして入れ替えられる機能とが噛み合ってなくておかしな感じになっていた。

[![Image from Gyazo](https://i.gyazo.com/e97a31bbc632064ca30fc60c1b0bc92c.png)](https://gyazo.com/e97a31bbc632064ca30fc60c1b0bc92c)