### PR TITLE
relay-configをアンインストール

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -99,8 +99,7 @@
     "cra-bundle-analyzer": "^0.1.0",
     "graphql": "^15.5.0",
     "prettier": "^2.3.1",
-    "relay-compiler": "^13.0.1",
-    "relay-config": "^11.0.2"
+    "relay-compiler": "^13.0.1"
   },
   "resolutions": {
     "mini-css-extract-plugin": "~2.4.5",

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -9130,13 +9130,6 @@ relay-compiler@^13.0.1:
   resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-13.0.1.tgz#09c713647aa7e1d8cf3de9f7fb4ee6a76b32cf26"
   integrity sha512-C/qJ7IdfZ140b9JaNpuAP6WhV/Odt/tIq4sUZoTwsaOlhs+1Zu3fvIOoWKTnZT5PC6krRuw1hD7GSX6/paVpTQ==
 
-relay-config@^11.0.2:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/relay-config/-/relay-config-11.0.2.tgz#d1e5bbac795dfe0a414ed61c94faabdef7db99c5"
-  integrity sha512-j/bl04lGwZ+xSM/21KN87lPXY6t7YWkStfST63dQhJN35F6gQKZevmxVVPlEJ7Qs41AyrY1kilGBIfbEZPPdSA==
-  dependencies:
-    cosmiconfig "^5.0.5"
-
 relay-runtime@13.0.1, relay-runtime@^13.0.1:
   version "13.0.1"
   resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-13.0.1.tgz#7e59a07c3b4e8c58d04bc94f6f978822d4128ffb"


### PR DESCRIPTION
>Only works with Relay 12 and below, Relay 13 does not use this format
>https://www.npmjs.com/package/relay-config