### PR TITLE
Artwork.editableの実装をモデルに持たせる

### DIFF
--- a/api/src/goduploader/graphql/type/artwork.py
+++ b/api/src/goduploader/graphql/type/artwork.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 import graphene
 from goduploader.db import session
 from goduploader.graphql.dataloader import AccountLoader, IllustLoader
@@ -64,7 +65,9 @@ class Artwork(SQLAlchemyObjectType):
             .first()
         )
 
-    editable = graphene.Field(graphene.Boolean, required=True, description="作品の情報を編集できるかどうかを返す")
+    editable = graphene.Field(
+        graphene.Boolean, required=True, description="作品の情報を編集できるかどうかを返す"
+    )
 
     def resolve_editable(root, info):
         if not info.context:
@@ -75,4 +78,4 @@ class Artwork(SQLAlchemyObjectType):
         if not user:
             return False
 
-        return root.can_edit(user)
+        return root.user_can_edit(user)

--- a/api/src/goduploader/graphql/type/mutation/delete_artwork.py
+++ b/api/src/goduploader/graphql/type/mutation/delete_artwork.py
@@ -26,7 +26,7 @@ class DeleteArtwork(graphene.ClientIDMutation):
         if artwork is None:
             raise Exception("Artwork not found")
 
-        if not artwork.can_edit(current_user):
+        if not artwork.user_can_edit(current_user):
             raise Exception("You cannot delete this artwork")
 
         for tag in artwork.tags:

--- a/api/src/goduploader/graphql/type/mutation/update_artwork.py
+++ b/api/src/goduploader/graphql/type/mutation/update_artwork.py
@@ -32,7 +32,7 @@ class UpdateArtwork(graphene.ClientIDMutation):
         if artwork is None:
             raise Exception("Artwork not found")
 
-        if not artwork.can_edit(current_user):
+        if not artwork.user_can_edit(current_user):
             raise Exception("You cannot update this artwork")
 
         artwork.title = input["title"]

--- a/api/src/goduploader/model/artwork.py
+++ b/api/src/goduploader/model/artwork.py
@@ -49,5 +49,5 @@ class Artwork(Base):
         back_populates="artworks",
     )
 
-    def can_edit(self, user: Account):
+    def user_can_edit(self, user: Account):
         return self.account_id == user.id


### PR DESCRIPTION
close #58

GraphQL APIを使う側から見たら、作品が編集可能かどうかがArtworkのフィールドを見たら分かる、というのは自然だと思うけど、モデルの立場に立つとどうあるのがよいのか。
`Account.can_edit(artwork)` の方が自然？