### PR TITLE
フロントエンドをk8s環境向けにデプロイできるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ all: front api
 
 front: front/install front/build front/deploy
 
+front-k8s: front/install front-k8s/build front-k8s/deploy
+
 front/install:
 	cd front && yarn install --frozen-lockfile
 
@@ -11,6 +13,12 @@ front/build:
 front/deploy:
 	rsync -auv --delete-after front/build/ front/_app/
 
+front-k8s/build:
+	cd front && env DISABLE_ESLINT_PLUGIN=true DISABLE_ESLINT_PLUGIN=true PUBLIC_URL=/ REACT_APP_BASENAME=/ yarn build
+
+front-k8s/deploy:
+	rsync -auv --delete-after front/build/ front/_app_k8s/
+
 api: api/install api/restart
 
 api/install:
@@ -19,4 +27,4 @@ api/install:
 api/restart:
 	passenger-config restart-app .
 
-.PHONY: all front front/install front/build api api/install
+.PHONY: all front front/install front/build front-k8s/build front-k8s/deploy api api/install

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -11,6 +11,7 @@
 # production
 /build
 /_app
+/_app_k8s
 
 # misc
 .DS_Store


### PR DESCRIPTION
ひどいけど、dotenvを打ち消すために環境変数を渡しつつ別ディレクトリにデプロイします