### PR TITLE
APIとフロントエンドでpushするイメージ名を変える

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: goduploader
+      IMAGE_NAME: goduploader-graphql
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: goduploader-front
+      IMAGE_NAME: goduploader-graphql-front
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
イメージの内容が違うなら異なる名前を付けてpushするのが望ましい。

ついでにworkflow_dispatch対応した。