### PR TITLE
MySQLの起動と並行してCIの初期設定を進める

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -27,11 +27,6 @@ jobs:
         env:
           MYSQL_DATABASE: goduploader_test
           MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        options: >-
-          --health-cmd "mysqladmin ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       DB_URL: mysql+mysqlconnector://root@localhost:3306/goduploader_test
       MYSQL_USER: root


### PR DESCRIPTION
- mysqlイメージに `MYSQL_DATABASE` 環境変数を渡すと、コンテナ作成時にDBを作ってくれる
- テストの直前にMySQLコンテナに疎通できることを確認する