### PR TITLE
作品のタグを年齢制限カラムに反映するスクリプト

### DIFF
--- a/api/script/sync_tag_to_rating.py
+++ b/api/script/sync_tag_to_rating.py
@@ -12,11 +12,15 @@ def sync_tag_to_rating():
 
         for artwork in all_artworks:
             artwork: Artwork
-            tags: List[Tag] = artwork.tags
-            canonical_tag_names: List[str] = [t.canonical_name for t in tags]
 
+            # rating != safe なら https://github.com/kmc-jp/GodUploader-graphql/pull/141 のリリース以降に投稿され、
+            # ratingカラムの値が有効なのでスキップする
             if artwork.rating != ArtworkRatingEnum.safe:
                 continue
+
+            # rating == safe なら、ratingカラムの値がタグと同期されていないので同期する
+            tags: List[Tag] = artwork.tags
+            canonical_tag_names: List[str] = [t.canonical_name for t in tags]
 
             if 'r-18g' in canonical_tag_names:
                 rating = ArtworkRatingEnum.r_18g

--- a/api/script/sync_tag_to_rating.py
+++ b/api/script/sync_tag_to_rating.py
@@ -1,0 +1,31 @@
+"""
+作品のタグ (Artwork.tags) を年齢制限 (Artwork.rating) に反映するスクリプト
+"""
+from typing import List
+from goduploader.db import session
+from goduploader.model.artwork import Artwork, ArtworkRatingEnum
+from goduploader.model.tag import Tag
+
+def sync_tag_to_rating():
+    with session.begin():
+        all_artworks = session.query(Artwork).all()
+
+        for artwork in all_artworks:
+            artwork: Artwork
+            tags: List[Tag] = artwork.tags
+            canonical_tag_names: List[str] = [t.canonical_name for t in tags]
+
+            if artwork.rating != ArtworkRatingEnum.safe:
+                continue
+
+            if 'r-18g' in canonical_tag_names:
+                rating = ArtworkRatingEnum.r_18g
+            elif 'r-18' in canonical_tag_names:
+                rating = ArtworkRatingEnum.r_18
+            else:
+                rating = ArtworkRatingEnum.safe
+
+            artwork.rating = rating
+
+if __name__ == "__main__":
+    sync_tag_to_rating()

--- a/api/tests/script/test_sync_tag_to_rating.py
+++ b/api/tests/script/test_sync_tag_to_rating.py
@@ -1,0 +1,50 @@
+from goduploader.db import session
+from goduploader.model.artwork import Artwork, ArtworkRatingEnum
+from script.sync_tag_to_rating import sync_tag_to_rating
+from tests.util import create_artwork
+
+
+def test_sync_tag_to_rating():
+    create_artwork(
+        tags=["R-18G"],
+        rating=ArtworkRatingEnum.safe,
+        title="ratingカラムが同期されていない作品 (R-18G)",
+    )
+    create_artwork(
+        tags=["R-18"],
+        rating=ArtworkRatingEnum.safe,
+        title="ratingカラムが同期されていない作品 (R-18)",
+    )
+
+    create_artwork(
+        tags=["R-18G"],
+        rating=ArtworkRatingEnum.r_18g,
+        title="ratingカラムが同期されて、タグも付いている作品 (R-18G)",
+    )
+    create_artwork(
+        tags=["R-18"],
+        rating=ArtworkRatingEnum.r_18,
+        title="ratingカラムが同期されて、タグも付いている作品 (R-18)",
+    )
+
+    create_artwork(
+        rating=ArtworkRatingEnum.r_18g, title="ratingカラムが同期されて、タグが付いていない作品 (R-18G)"
+    )
+    create_artwork(
+        rating=ArtworkRatingEnum.r_18, title="ratingカラムが同期されて、タグが付いていない作品 (R-18)"
+    )
+    create_artwork(
+        rating=ArtworkRatingEnum.safe, title="ratingカラムが同期されて、タグが付いていない作品 (全年齢)"
+    )
+
+    sync_tag_to_rating()
+
+    after_artworks = session.query(Artwork).order_by(Artwork.id.asc()).all()
+
+    assert after_artworks[0].rating == ArtworkRatingEnum.r_18g, after_artworks[0].title
+    assert after_artworks[1].rating == ArtworkRatingEnum.r_18, after_artworks[1].title
+    assert after_artworks[2].rating == ArtworkRatingEnum.r_18g, after_artworks[2].title
+    assert after_artworks[3].rating == ArtworkRatingEnum.r_18, after_artworks[3].title
+    assert after_artworks[4].rating == ArtworkRatingEnum.r_18g, after_artworks[4].title
+    assert after_artworks[5].rating == ArtworkRatingEnum.r_18, after_artworks[5].title
+    assert after_artworks[6].rating == ArtworkRatingEnum.safe, after_artworks[6].title


### PR DESCRIPTION
#63

#141 をリリースして以降に投稿された作品は、全て年齢制限カラムに年齢制限タグ (R-18, R-18G) と同期した値が入っている。
それ以前の作品は、年齢制限タグがあり、かつ年齢制限カラムの値が `safe` になっているので、それらを同期します。