### PR TITLE
excludeする設定をworkspace側に移動

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,8 +14,4 @@
     "[typescriptreact]": {
       "editor.formatOnSave": true,
     },
-    "files.exclude": {
-      "api/**": true,
-      "front/**": true
-    },
 }

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -13,5 +13,11 @@
       "path": ".",
     }
   ],
-  "settings": {}
+  "settings": {
+    "files.exclude": {
+      // multi-root workspaceのとき、root workspaceから各workspaceのディレクトリが見えないようにする
+      "api/**": true,
+      "front/**": true,
+    }
+  }
 }

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -16,6 +16,7 @@
   "settings": {
     "files.exclude": {
       // multi-root workspaceのとき、root workspaceから各workspaceのディレクトリが見えないようにする
+      // 素朴に .vscode/settings.json に書いてしまうと、workspaceを開いていないときにディレクトリが見えなくなってしまう
       "api/**": true,
       "front/**": true,
     }


### PR DESCRIPTION
素朴にsettings.jsonでexcludeすると、workspaceを開いていない場合に `api` `front` ディレクトリが見えなくなってしまう