### PR TITLE
リロードせずに複数回投稿できるようにする

### DIFF
--- a/front/src/pages/UploadArtwork.tsx
+++ b/front/src/pages/UploadArtwork.tsx
@@ -67,7 +67,6 @@ const UploadArtworkForm = () => {
         setFiles((files) =>
           e.target.files ? [...files, ...Array.from(e.target.files)] : files
         );
-        e.target.value = "";
       },
       [setFiles]
     );


### PR DESCRIPTION
一度作品を投稿したあと、同じセッションで再び投稿しようとファイルをアップロードしても反映されていなかった。`e.target.value` を消すのをやめたらうまく動いていそうなのでこれでいく。
2回目以降のrenderでは、 `setFiles` のコールバックが呼ばれるよりも先に `e.target.files` が消えてしまっていたのかも。