### PR TITLE
React.FC撲滅

### DIFF
--- a/front/src/components/ArtworkDetail/ArtworkLikeList.tsx
+++ b/front/src/components/ArtworkDetail/ArtworkLikeList.tsx
@@ -11,7 +11,7 @@ interface Props {
   artwork: ArtworkLikeList_likes$key;
 }
 
-export const LikeList: React.FC<Props> = ({ artwork }) => {
+export const LikeList: React.VFC<Props> = ({ artwork }) => {
   const { artworkId, likes } = useFragment<ArtworkLikeList_likes$key>(
     graphql`
       fragment ArtworkLikeList_likes on Artwork {
@@ -83,14 +83,16 @@ export const LikeList: React.FC<Props> = ({ artwork }) => {
   );
 };
 
-const LikeIcon: React.FC<{
+interface LikeIconProps {
   like: {
     readonly account: {
       readonly id: string;
       readonly kmcid: string;
     } | null;
   };
-}> = ({ like }) => {
+}
+
+const LikeIcon: React.VFC<LikeIconProps> = ({ like }) => {
   const ref = useTooltip<HTMLAnchorElement>();
 
   if (!like.account) {

--- a/front/src/components/LoadingOverlay.tsx
+++ b/front/src/components/LoadingOverlay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import styles from "./LoadingOverlay.module.css";
 
-export const LoadingOverlay: React.FC = () => {
+export const LoadingOverlay: React.VFC = () => {
   return (
     <div className={styles.Overlay}>
       <div className="position-absolute top-50 start-50 translate-middle">

--- a/front/src/components/TegakiDU/Sidebar.tsx
+++ b/front/src/components/TegakiDU/Sidebar.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useContext, useState } from "react";
 
 import { ArtworkInformationProvider } from "../../contexts/ArtworkInformationContext";
-import { UploadArtworkProvider } from "../../contexts/UploadArtworkContext";
 import { DrawingContext } from "../../contexts/TegakiDU/DrawingContext";
 import { PaintStackContext } from "../../contexts/TegakiDU/PaintStackContext";
+import { UploadArtworkProvider } from "../../contexts/UploadArtworkContext";
 import { UploadArtworkModal } from "./UploadArtworkModal";
 
 export const Sidebar: React.VFC = () => {

--- a/front/src/contexts/ArtworkInformationContext.tsx
+++ b/front/src/contexts/ArtworkInformationContext.tsx
@@ -43,14 +43,15 @@ const defaultInformation: ArtworkInformationContextValue = {
 export const ArtworkInformationContext =
   createContext<ArtworkInformationContextValue>(defaultInformation);
 
-type ArtworkInformationProviderProps = {
+interface ArtworkInformationProviderProps {
   initialTitle?: string;
   initialCaption?: string;
   initialTags?: string[];
   initialAgeRestriction?: AgeRestriction;
-};
+  children: React.ReactNode;
+}
 
-export const ArtworkInformationProvider: React.FC<ArtworkInformationProviderProps> =
+export const ArtworkInformationProvider: React.VFC<ArtworkInformationProviderProps> =
   ({
     initialTitle,
     initialCaption,

--- a/front/src/contexts/TegakiDU/DrawingContext.tsx
+++ b/front/src/contexts/TegakiDU/DrawingContext.tsx
@@ -33,7 +33,13 @@ export const DrawingContext = React.createContext<DrawingContextValue>(
   defaultDrawingContextValue
 );
 
-export const DrawingProvider: React.FC = ({ children }) => {
+interface DrawingProviderProps {
+  children: React.ReactNode;
+}
+
+export const DrawingProvider: React.VFC<DrawingProviderProps> = ({
+  children,
+}) => {
   const [color, setColor] = useState("#000000");
   const [backgroundColor, setBackgroundColor] = useState("#ffffff");
   const [strokeWidth, setStrokeWidth] = useState(2);

--- a/front/src/contexts/TegakiDU/PaintStackContext.tsx
+++ b/front/src/contexts/TegakiDU/PaintStackContext.tsx
@@ -38,7 +38,11 @@ export const PaintStackContext = createContext<PaintStackContextValue>({
   /* eslint-enable @typescript-eslint/no-empty-function */
 });
 
-export const PaintStackContextProvider: React.FC = ({ children }) => {
+interface PaintStackContextProviderProps {
+  children: React.ReactNode
+}
+
+export const PaintStackContextProvider: React.VFC<PaintStackContextProviderProps> = ({ children }) => {
   const [paints, setPaints] = useState<Drawing[]>([]);
   const {
     append,

--- a/front/src/contexts/UploadArtworkContext.tsx
+++ b/front/src/contexts/UploadArtworkContext.tsx
@@ -90,7 +90,13 @@ export const MAX_FILESIZE = MAX_FILESIZE_MB * 0.95 * 1024 * 1024;
 export const UploadArtworkContext =
   createContext<UplaodArtworkContextValue>(defaultValue);
 
-export const UploadArtworkProvider: React.FC = ({ children }) => {
+interface UploadArtworkProviderProps {
+  children: React.ReactNode;
+}
+
+export const UploadArtworkProvider: React.VFC<UploadArtworkProviderProps> = ({
+  children,
+}) => {
   const { title, caption, tags, ageRestriction } = useArtworkInformation();
   const [isUploading, setIsUploading] = useState(false);
   const [files, setFiles] = useState<File[] | Blob[]>([]);

--- a/front/src/pages/UserDetail.tsx
+++ b/front/src/pages/UserDetail.tsx
@@ -10,7 +10,7 @@ import { ArtworkListPaginationQuery } from "./__generated__/ArtworkListPaginatio
 import { UserDetailQuery } from "./__generated__/UserDetailQuery.graphql";
 import { UserDetail_artworks$key } from "./__generated__/UserDetail_artworks.graphql";
 
-export const UserDetail: React.FC = () => {
+export const UserDetail: React.VFC = () => {
   const { kmcid } = useParams<{ kmcid: string }>();
   const { user } = useLazyLoadQuery<UserDetailQuery>(
     graphql`

--- a/front/src/router/Router.tsx
+++ b/front/src/router/Router.tsx
@@ -6,7 +6,11 @@ const history = createBrowserHistory({
   basename: process.env.REACT_APP_BASENAME,
 });
 
-export const Router: React.FC = ({ children }) => {
+interface RouterProps {
+  children: React.ReactNode;
+}
+
+export const Router: React.VFC<RouterProps> = ({ children }) => {
   const [forceRefresh, setForceRefresh] = useState(false);
 
   // 暫定的に、5分おきにページ遷移時に再読み込みされるようにする


### PR DESCRIPTION
#198 の下準備。React 18以降の型定義では `React.FC` 相当のものが廃止されているので、予め対応する。