### PR TITLE
ひとまずget-poetry.pyのdeprecation warningを無視する

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,6 +12,8 @@ ENV PIP_NO_CACHE_DIR=yes
 ENV PIP_DISABLE_PIP_VERSION_CHECK=yes
 ENV POETRY_HOME="/opt/poetry"
 ENV POETRY_NO_INTERACTION=1
+# XXX: ひとまずget-poetry.pyのdeprecation warningを無視する
+ENV GET_POETRY_IGNORE_DEPRECATION=1
 ENV PATH="$POETRY_HOME/bin:$PATH"
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 RUN chmod 755 $POETRY_HOME/bin/poetry


### PR DESCRIPTION
手元でサクッと起動できることを優先。あとでちゃんとみる