### PR TITLE
ついにget-poetry.pyが消滅していた

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,10 +12,8 @@ ENV PIP_NO_CACHE_DIR=yes
 ENV PIP_DISABLE_PIP_VERSION_CHECK=yes
 ENV POETRY_HOME="/opt/poetry"
 ENV POETRY_NO_INTERACTION=1
-# XXX: ひとまずget-poetry.pyのdeprecation warningを無視する
-ENV GET_POETRY_IGNORE_DEPRECATION=1
 ENV PATH="$POETRY_HOME/bin:$PATH"
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+RUN curl -sSL https://install.python-poetry.org | python3 -
 RUN chmod 755 $POETRY_HOME/bin/poetry
 
 COPY ./poetry.toml ./


### PR DESCRIPTION
deprecation warningを無視していたオレが全て悪い！！ https://python-poetry.org/docs/#installation に沿います。