### PR TITLE
CREATE TABLE文をdumpするスクリプト

### DIFF
--- a/api/script/dump_create_table_sql.py
+++ b/api/script/dump_create_table_sql.py
@@ -1,0 +1,6 @@
+from goduploader.db import engine
+from goduploader.model import Base
+from sqlalchemy.schema import CreateTable
+
+for t in Base.metadata.sorted_tables:
+    print(str(CreateTable(t).compile(engine, dialect=engine.dialect)).strip(), end=';\n')


### PR DESCRIPTION
#294

- SQLite移行後は、sqldefを使ってマイグレーションを行うことにする
- SQLAlchemyのモデル定義とDDLで二重管理になると、修正漏れが発生することが容易に想像できるため、SQLAlchemyのモデル定義を正としてDDLを生成できるようにする