### PR TITLE
Redirectコンポーネントによるページ遷移が動作しない問題を修正

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -28,7 +28,7 @@ export const App: React.VFC = () => {
         if (action === "PUSH") {
           window.scrollTo(0, 0);
         }
-        if (action === "POP") {
+        if (action === "POP" || action === "REPLACE") {
           startTransition(() => {
             setDisplayLocation(location);
           });


### PR DESCRIPTION
## 概要

`Redirect` コンポーネントを使ったページ遷移が `useTransition` 導入後に動作しなくなっていた問題を修正します。

## 原因

`Redirect` は内部で `history.replace()` を呼び出しますが、`App.tsx` の `history.listen` では `POP`（ブラウザの戻る/進む）アクションしか `startTransition` に流していなかったため、`displayLocation` が更新されず画面が切り替わらない状態になっていました。

## 修正内容

`history.listen` の処理対象に `REPLACE` アクションを追加し、`Redirect` や `navigate(to, replace=true)` による遷移でも `displayLocation` が正しく更新されるようにしました。

https://claude.ai/code/session_01WZLvssijCebiNJt9LtQUPc