### PR TITLE
MSW (Mock Service Worker) でGraphQL APIをモックできるようにする

### DIFF
--- a/front/codegen.fabbrica.yml
+++ b/front/codegen.fabbrica.yml
@@ -1,0 +1,13 @@
+schema: ./schema.graphql
+generates:
+  ./src/mocks/__generated__/types.ts:
+    plugins:
+      - typescript
+    config:
+      enumsAsTypes: true
+      avoidOptionals: true
+  ./src/mocks/__generated__/fabbrica.ts:
+    plugins:
+      - "@mizdra/graphql-codegen-typescript-fabbrica"
+    config:
+      typesFile: "./types"

--- a/front/eslint.config.js
+++ b/front/eslint.config.js
@@ -7,6 +7,7 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 export default defineConfig(
+  { ignores: ["src/mocks/__generated__/", "public/mockServiceWorker.js"] },
   eslint.configs.recommended,
   tseslint.configs.recommended,
   {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -44,6 +44,8 @@
         "@eslint/js": "^9.17.0",
         "@graphql-codegen/cli": "^6.1.0",
         "@graphql-codegen/schema-ast": "^6.0.0",
+        "@graphql-codegen/typescript": "^6.0.1",
+        "@mizdra/graphql-codegen-typescript-fabbrica": "^0.6.1",
         "@testing-library/react": "^11.1.0",
         "@testing-library/react-hooks": "^7.0.0",
         "@testing-library/user-event": "^12.1.10",
@@ -56,8 +58,9 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "glob": "^13.0.0",
         "globals": "^15.13.0",
-        "graphql": "^15.5.0",
+        "graphql": "^16.14.0",
         "happy-dom": "^20.8.9",
+        "msw": "^2.14.6",
         "prettier": "^2.3.1",
         "react-test-renderer": "^18.2.0",
         "relay-compiler": "^14.1.0",
@@ -70,40 +73,18 @@
       }
     },
     "node_modules/@ardatan/relay-compiler": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-12.3.0.tgz",
-      "integrity": "sha512-lc6PyM1IQCSa87DMChfv61HuhrSquHGhsF+WFSm2csFnKMSHaj0S1M8fnGr04i7O9YnwyR+OcgQ3CfzlEPC9Fg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@ardatan/relay-compiler/-/relay-compiler-13.0.1.tgz",
+      "integrity": "sha512-afG3YPwuSA0E5foouZusz5GlXKs74dObv4cuWyLyfKsYFj2r7oGRNB28v18HvwuLSQtQFCi+DpIe0TZkgQDYyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/generator": "^7.26.10",
-        "@babel/parser": "^7.26.10",
-        "@babel/runtime": "^7.26.10",
-        "chalk": "^4.0.0",
-        "fb-watchman": "^2.0.0",
+        "@babel/runtime": "^7.29.2",
         "immutable": "^5.1.5",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "relay-runtime": "12.0.0",
-        "signedsource": "^1.0.0"
-      },
-      "bin": {
-        "relay-compiler": "bin/relay-compiler"
+        "invariant": "^2.2.4"
       },
       "peerDependencies": {
         "graphql": "*"
-      }
-    },
-    "node_modules/@ardatan/relay-compiler/node_modules/relay-runtime": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
-      "integrity": "sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "fbjs": "^3.0.0",
-        "invariant": "^2.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -392,9 +373,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1427,6 +1408,128 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/schema-ast": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.2.tgz",
+      "integrity": "sha512-jl1F/9IjRkJisEb9B0ayG4QGqYlPldLRy8ojDdmL9NE1NsdB5ROfxQnSqyC3g+wuvBhWX7kZgMRQYn3RU1I5bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-tools/utils": "^11.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/schema-ast/node_modules/@graphql-tools/utils": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.0.tgz",
+      "integrity": "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/schema-ast/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/typescript": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.10.tgz",
+      "integrity": "sha512-Pa8OFmL9TdhEYnLYJLYA9EhP8eEeivP/YDYq4Nb8LQaL7GXm4TGX8zELYaCM9Fu8M3iZb7iQGMt7qc+1lXz8XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/schema-ast": "^5.0.2",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/typescript/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.3.0.tgz",
+      "integrity": "sha512-vGBoE+4huzZyNhyGSAhXAkdROHlwKxxuziZm4XtP1mxe7nuI+VgyOmXebafLijbmuDsptPXQN0C/htL54O8hrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.0.tgz",
+      "integrity": "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-tools/utils": {
       "version": "10.11.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
@@ -1749,17 +1852,17 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/typescript": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.7.tgz",
-      "integrity": "sha512-kZwcu9Iat5RWXxLGPnDbG6qVbGTigF25/aGqCG/DCQ1Al8RufSjVXhIOkJBp7QWAqXn3AupHXL1WTMXP7xs4dQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-6.0.1.tgz",
+      "integrity": "sha512-UmHKlOBqnmGs0ioZsfi7INIb6+YCXVMi3KSp/INO359fT3RJxWPLPiE7T30UaWXtLeO6fBNZcvhy3EGBI9UCvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.1.0",
-        "@graphql-codegen/schema-ast": "^5.0.0",
-        "@graphql-codegen/visitor-plugin-common": "6.2.2",
-        "auto-bind": "~4.0.0",
-        "tslib": "~2.6.0"
+        "@graphql-codegen/plugin-helpers": "^7.0.0",
+        "@graphql-codegen/schema-ast": "^6.0.0",
+        "@graphql-codegen/visitor-plugin-common": "^7.0.1",
+        "auto-bind": "^5.0.0",
+        "tslib": "~2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -1821,17 +1924,15 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-6.3.0.tgz",
-      "integrity": "sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==",
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/schema-ast": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.2.tgz",
+      "integrity": "sha512-jl1F/9IjRkJisEb9B0ayG4QGqYlPldLRy8ojDdmL9NE1NsdB5ROfxQnSqyC3g+wuvBhWX7kZgMRQYn3RU1I5bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
         "@graphql-tools/utils": "^11.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1841,42 +1942,50 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.0.tgz",
-      "integrity": "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/schema-ast/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/schema-ast": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-5.0.0.tgz",
-      "integrity": "sha512-jn7Q3PKQc0FxXjbpo9trxzlz/GSFQWxL042l0iC8iSbM/Ar+M7uyBwMtXPsev/3Razk+osQyreghIz0d2+6F7Q==",
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/typescript": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-5.0.10.tgz",
+      "integrity": "sha512-Pa8OFmL9TdhEYnLYJLYA9EhP8eEeivP/YDYq4Nb8LQaL7GXm4TGX8zELYaCM9Fu8M3iZb7iQGMt7qc+1lXz8XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^6.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "tslib": "~2.6.0"
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-codegen/schema-ast": "^5.0.2",
+        "@graphql-codegen/visitor-plugin-common": "^6.3.0",
+        "auto-bind": "~4.0.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-6.3.0.tgz",
+      "integrity": "sha512-vGBoE+4huzZyNhyGSAhXAkdROHlwKxxuziZm4XtP1mxe7nuI+VgyOmXebafLijbmuDsptPXQN0C/htL54O8hrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^6.3.0",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -1885,24 +1994,91 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-tools/utils": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
-      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+    "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/typescript/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-7.0.2.tgz",
+      "integrity": "sha512-3v1dPjkSiAIsqwZ/6btSZ6BCYlYYpr3FdLhsBZ/JoPP2hYgN6AlGKdUyhYm5FsgDKU04L7al3+rfnTOCxqM0gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "tslib": "^2.4.0"
+        "@graphql-codegen/plugin-helpers": "^7.0.0",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.1.1",
+        "@graphql-tools/utils": "^11.0.0",
+        "auto-bind": "^5.0.0",
+        "change-case-all": "^2.1.0",
+        "dependency-graph": "^1.0.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "^2.8.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/change-case-all": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-2.1.0.tgz",
+      "integrity": "sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "^5.2.0",
+        "sponge-case": "^2.0.2",
+        "swap-case": "^3.0.2",
+        "title-case": "^3.0.3"
+      }
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/sponge-case": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sponge-case/-/sponge-case-2.0.3.tgz",
+      "integrity": "sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/swap-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-3.0.3.tgz",
+      "integrity": "sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
       "version": "6.2.2",
@@ -2783,33 +2959,14 @@
       }
     },
     "node_modules/@graphql-tools/relay-operation-optimizer": {
-      "version": "7.0.26",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.26.tgz",
-      "integrity": "sha512-cVdS2Hw4hg/WgPVV2wRIzZM975pW5k4vdih3hR4SvEDQVr6MmozmlTQSqzMyi9yg8LKTq540Oz3bYQa286yGmg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.1.4.tgz",
+      "integrity": "sha512-cwOD/GEo/R//1uGCP0/urIxsMFoUgzkJVyMt9BDM2HhQhU6rSgH5l6lFukAFTJyPJVdyeOdYm2i0Jj5vYWbHTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ardatan/relay-compiler": "^12.0.3",
-        "@graphql-tools/utils": "^10.11.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/relay-operation-optimizer/node_modules/@graphql-tools/utils": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
-      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
+        "@ardatan/relay-compiler": "^13.0.1",
+        "@graphql-tools/utils": "^11.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3439,6 +3596,133 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mizdra/graphql-codegen-typescript-fabbrica": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@mizdra/graphql-codegen-typescript-fabbrica/-/graphql-codegen-typescript-fabbrica-0.6.1.tgz",
+      "integrity": "sha512-Sa50LZAY0j1FL1MS6ebialT/lW7yigTiID4keVu0oi3sh/JgTE4sPeYEAlTHAUtI2c0r6EHMZNREhRCMgVRYIg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "e2e/01-esm",
+        "e2e/02-cjs",
+        "e2e/03-browser"
+      ],
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.1",
+        "@graphql-codegen/visitor-plugin-common": "^4.0.1",
+        "graphql-relay": "^0.10.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.0.0"
+      }
+    },
+    "node_modules/@mizdra/graphql-codegen-typescript-fabbrica/node_modules/@graphql-codegen/plugin-helpers": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.1.1.tgz",
+      "integrity": "sha512-28GHODK2HY1NhdyRcPP3sCz0Kqxyfiz7boIZ8qIxFYmpLYnlDgiYok5fhFLVSZihyOpCs4Fa37gVHf/Q4I2FEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.0",
+        "change-case-all": "1.0.15",
+        "common-tags": "1.8.2",
+        "import-from": "4.0.0",
+        "lodash": "~4.17.0",
+        "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@mizdra/graphql-codegen-typescript-fabbrica/node_modules/@graphql-codegen/visitor-plugin-common": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-4.1.2.tgz",
+      "integrity": "sha512-yk7iEAL1kYZ2Gi/pvVjdsZhul5WsYEM4Zcgh2Ev15VicMdJmPHsMhNUsZWyVJV0CaQCYpNOFlGD/11Ea3pn4GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": "^5.0.3",
+        "@graphql-tools/optimize": "^2.0.0",
+        "@graphql-tools/relay-operation-optimizer": "^7.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
+        "dependency-graph": "^0.11.0",
+        "graphql-tag": "^2.11.0",
+        "parse-filepath": "^1.0.2",
+        "tslib": "~2.6.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@mizdra/graphql-codegen-typescript-fabbrica/node_modules/@graphql-tools/utils": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+      "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@mizdra/graphql-codegen-typescript-fabbrica/node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/@mizdra/graphql-codegen-typescript-fabbrica/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3476,6 +3760,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@popperjs/core": {
       "version": "2.9.2",
@@ -4305,8 +4614,25 @@
       "version": "13.0.0",
       "license": "MIT"
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sizzle": {
       "version": "2.3.3",
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -5479,16 +5805,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-int64": "^0.4.0"
-      }
-    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "dev": true,
@@ -5918,6 +6234,20 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.1",
@@ -7193,6 +7523,33 @@
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastest-stable-stringify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
@@ -7206,16 +7563,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fb-watchman": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bser": "2.1.1"
       }
     },
     "node_modules/fbjs": {
@@ -7678,11 +8025,13 @@
       }
     },
     "node_modules/graphql": {
-      "version": "15.5.0",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-config": {
@@ -8001,6 +8350,19 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/graphql-relay": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.10.2.tgz",
+      "integrity": "sha512-abybva1hmlNt7Y9pMpAzHuFnM2Mme/a2Usd8S4X27fNteLGRAECMYfhmsrpZFvGn3BhmBZugMXYW/Mesv3P1Kw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >= 15.9.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.2.0"
+      }
+    },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
@@ -8162,6 +8524,17 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
       }
     },
     "node_modules/hermes-estree": {
@@ -8621,6 +8994,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -9494,6 +9874,155 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.6.tgz",
+      "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/confirm": {
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.13.tgz",
+      "integrity": "sha512-wkGPC7yJ5WJk1DJ5SX7fzk+gfj4BM8cf5dDDi71B/551xHrdsZVRJOC0WyikXd0pEsb/9cLniuE4atbsMqmFkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/core": {
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.10.tgz",
+      "integrity": "sha512-a4Q5BXHQAHa9eO202sTaFCHFYVB3x5fauDuThEAdZ9gfn76pSxiKU7wWcEH0N1O0XmQvNfQNU6QXpiRxmYQx+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/msw/node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -9594,13 +10123,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
       }
-    },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -9919,6 +10441,13 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "dev": true
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -10792,6 +11321,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -11075,6 +11611,13 @@
         "upper-case-first": "^2.0.2"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -11280,13 +11823,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/signedsource": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
-      "integrity": "sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11415,6 +11951,16 @@
         "stacktrace-gps": "^3.0.4"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -11455,6 +12001,13 @@
         "readable-stream": "^3.6.0",
         "xtend": "^4.0.2"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -11699,6 +12252,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/throttle-debounce": {
       "version": "3.0.1",
       "license": "MIT",
@@ -11820,6 +12386,26 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -11857,6 +12443,19 @@
       "version": "1.0.6",
       "license": "MIT"
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -11890,6 +12489,22 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
@@ -12071,6 +12686,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/front/package.json
+++ b/front/package.json
@@ -40,6 +40,7 @@
     "build": "tsc && env VITE_REVISION=`git rev-parse HEAD` VITE_BUILT_AT=`date +%s` vite build",
     "test": "vitest",
     "codegen": "graphql-codegen",
+    "codegen:mocks": "graphql-codegen --config codegen.fabbrica.yml",
     "relay-compiler": "node node_modules/relay-compiler/cli.js",
     "eslint": "eslint",
     "tsc": "tsc"
@@ -76,6 +77,8 @@
     "@eslint/js": "^9.17.0",
     "@graphql-codegen/cli": "^6.1.0",
     "@graphql-codegen/schema-ast": "^6.0.0",
+    "@graphql-codegen/typescript": "^6.0.1",
+    "@mizdra/graphql-codegen-typescript-fabbrica": "^0.6.1",
     "@testing-library/react": "^11.1.0",
     "@testing-library/react-hooks": "^7.0.0",
     "@testing-library/user-event": "^12.1.10",
@@ -88,8 +91,9 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "glob": "^13.0.0",
     "globals": "^15.13.0",
-    "graphql": "^15.5.0",
+    "graphql": "^16.14.0",
     "happy-dom": "^20.8.9",
+    "msw": "^2.14.6",
     "prettier": "^2.3.1",
     "react-test-renderer": "^18.2.0",
     "relay-compiler": "^14.1.0",
@@ -102,5 +106,10 @@
   },
   "resolutions": {
     "@types/relay-runtime": "~13.0.0"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/front/public/mockServiceWorker.js
+++ b/front/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/front/public/mocks/placeholder.svg
+++ b/front/public/mocks/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#cccccc"/>
+  <text x="400" y="310" font-family="sans-serif" font-size="32" fill="#888888" text-anchor="middle">mock image</text>
+</svg>

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -8,13 +8,21 @@ import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
 import RelayEnvironment from "./RelayEnvironment";
 
+async function enableMocking() {
+  if (import.meta.env.VITE_USE_MSW !== "1") return;
+  const { worker } = await import("./mocks/browser");
+  return worker.start({ onUnhandledRequest: "warn" });
+}
+
 // opt-out Strict mode of React. ref: https://github.com/ReactTraining/react-router/issues/7870
 
-const root = createRoot(document.getElementById("root")!);
-root.render(
-  <RelayEnvironmentProvider environment={RelayEnvironment}>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </RelayEnvironmentProvider>
-);
+enableMocking().then(() => {
+  const root = createRoot(document.getElementById("root")!);
+  root.render(
+    <RelayEnvironmentProvider environment={RelayEnvironment}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </RelayEnvironmentProvider>
+  );
+});

--- a/front/src/mocks/__generated__/fabbrica.ts
+++ b/front/src/mocks/__generated__/fabbrica.ts
@@ -1,0 +1,831 @@
+import {
+  type DefineTypeFactoryInterface,
+  defineTypeFactory,
+} from '@mizdra/graphql-codegen-typescript-fabbrica/helper';
+import type {
+  Maybe,
+  Account,
+  AccountConnection,
+  AccountEdge,
+  Artwork,
+  ArtworkConnection,
+  ArtworkEdge,
+  Comment,
+  CommentConnection,
+  CommentEdge,
+  CreateCommentInput,
+  CreateCommentPayload,
+  DeleteArtworkInput,
+  DeleteArtworkPayload,
+  Illust,
+  IllustConnection,
+  IllustEdge,
+  Like,
+  LikeArtworkInput,
+  LikeArtworkPayload,
+  LikeConnection,
+  LikeEdge,
+  Mutation,
+  PageInfo,
+  Query,
+  SlackChannel,
+  Tag,
+  TagConnection,
+  TagEdge,
+  TwitterShareOption,
+  UpdateAccountInput,
+  UpdateAccountPayload,
+  UpdateArtworkInput,
+  UpdateArtworkPayload,
+  UpdateTagInput,
+  UpdateTagPayload,
+  UploadArtworkInput,
+  UploadArtworkPayload,
+} from './types';
+
+export * from '@mizdra/graphql-codegen-typescript-fabbrica/helper';
+
+export type OptionalAccount = {
+  __typename?: 'Account';
+  artworks?: Maybe<OptionalArtworkConnection> | undefined;
+  artworksCount?: Account['artworksCount'] | undefined;
+  comments?: Maybe<OptionalCommentConnection> | undefined;
+  createdAt?: Account['createdAt'] | undefined;
+  /** The ID of the object. */
+  id?: Account['id'] | undefined;
+  /** ログインユーザーかどうか */
+  isYou?: Account['isYou'] | undefined;
+  kmcid?: Account['kmcid'] | undefined;
+  lastLoggedIn?: Account['lastLoggedIn'] | undefined;
+  likes?: Maybe<OptionalLikeConnection> | undefined;
+  name?: Account['name'] | undefined;
+  updatedAt?: Account['updatedAt'] | undefined;
+};
+
+/**
+ * Define factory for {@link Account} model.
+ *
+ * @param options
+ * @returns factory {@link AccountFactoryInterface}
+ */
+export const defineAccountFactory: DefineTypeFactoryInterface<
+  OptionalAccount,
+  {}
+> = defineTypeFactory;
+
+export type OptionalAccountConnection = {
+  __typename?: 'AccountConnection';
+  /** Contains the nodes in this connection. */
+  edges?: Maybe<OptionalAccountEdge>[] | undefined;
+  /** Pagination data for this connection. */
+  pageInfo?: OptionalPageInfo | undefined;
+};
+
+/**
+ * Define factory for {@link AccountConnection} model.
+ *
+ * @param options
+ * @returns factory {@link AccountConnectionFactoryInterface}
+ */
+export const defineAccountConnectionFactory: DefineTypeFactoryInterface<
+  OptionalAccountConnection,
+  {}
+> = defineTypeFactory;
+
+/** A Relay edge containing a `Account` and its cursor. */
+export type OptionalAccountEdge = {
+  __typename?: 'AccountEdge';
+  /** A cursor for use in pagination */
+  cursor?: AccountEdge['cursor'] | undefined;
+  /** The item at the end of the edge */
+  node?: Maybe<OptionalAccount> | undefined;
+};
+
+/**
+ * Define factory for {@link AccountEdge} model.
+ *
+ * @param options
+ * @returns factory {@link AccountEdgeFactoryInterface}
+ */
+export const defineAccountEdgeFactory: DefineTypeFactoryInterface<
+  OptionalAccountEdge,
+  {}
+> = defineTypeFactory;
+
+export type OptionalArtwork = {
+  __typename?: 'Artwork';
+  account?: Maybe<OptionalAccount> | undefined;
+  accountId?: Artwork['accountId'] | undefined;
+  caption?: Artwork['caption'] | undefined;
+  comments?: Maybe<OptionalCommentConnection> | undefined;
+  createdAt?: Artwork['createdAt'] | undefined;
+  /** 作品の情報を編集できるかどうかを返す */
+  editable?: Artwork['editable'] | undefined;
+  /** The ID of the object. */
+  id?: Artwork['id'] | undefined;
+  illusts?: Maybe<OptionalIllustConnection> | undefined;
+  likes?: Maybe<OptionalLikeConnection> | undefined;
+  /** この作品より1つ新しい、同じユーザーの作品を返す */
+  nextArtwork?: Maybe<OptionalArtwork> | undefined;
+  nsfw?: Artwork['nsfw'] | undefined;
+  /** この作品より1つ古い、同じユーザーの作品を返す */
+  previousArtwork?: Maybe<OptionalArtwork> | undefined;
+  rating?: Artwork['rating'] | undefined;
+  tags?: Maybe<OptionalTagConnection> | undefined;
+  title?: Artwork['title'] | undefined;
+  topIllust?: Maybe<OptionalIllust> | undefined;
+  updatedAt?: Artwork['updatedAt'] | undefined;
+};
+
+/**
+ * Define factory for {@link Artwork} model.
+ *
+ * @param options
+ * @returns factory {@link ArtworkFactoryInterface}
+ */
+export const defineArtworkFactory: DefineTypeFactoryInterface<
+  OptionalArtwork,
+  {}
+> = defineTypeFactory;
+
+export type OptionalArtworkConnection = {
+  __typename?: 'ArtworkConnection';
+  /** Contains the nodes in this connection. */
+  edges?: Maybe<OptionalArtworkEdge>[] | undefined;
+  /** Pagination data for this connection. */
+  pageInfo?: OptionalPageInfo | undefined;
+};
+
+/**
+ * Define factory for {@link ArtworkConnection} model.
+ *
+ * @param options
+ * @returns factory {@link ArtworkConnectionFactoryInterface}
+ */
+export const defineArtworkConnectionFactory: DefineTypeFactoryInterface<
+  OptionalArtworkConnection,
+  {}
+> = defineTypeFactory;
+
+/** A Relay edge containing a `Artwork` and its cursor. */
+export type OptionalArtworkEdge = {
+  __typename?: 'ArtworkEdge';
+  /** A cursor for use in pagination */
+  cursor?: ArtworkEdge['cursor'] | undefined;
+  /** The item at the end of the edge */
+  node?: Maybe<OptionalArtwork> | undefined;
+};
+
+/**
+ * Define factory for {@link ArtworkEdge} model.
+ *
+ * @param options
+ * @returns factory {@link ArtworkEdgeFactoryInterface}
+ */
+export const defineArtworkEdgeFactory: DefineTypeFactoryInterface<
+  OptionalArtworkEdge,
+  {}
+> = defineTypeFactory;
+
+export type OptionalComment = {
+  __typename?: 'Comment';
+  account?: Maybe<OptionalAccount> | undefined;
+  accountId?: Comment['accountId'] | undefined;
+  artwork?: Maybe<OptionalArtwork> | undefined;
+  artworkId?: Comment['artworkId'] | undefined;
+  createdAt?: Comment['createdAt'] | undefined;
+  /** The ID of the object. */
+  id?: Comment['id'] | undefined;
+  text?: Comment['text'] | undefined;
+  updatedAt?: Comment['updatedAt'] | undefined;
+};
+
+/**
+ * Define factory for {@link Comment} model.
+ *
+ * @param options
+ * @returns factory {@link CommentFactoryInterface}
+ */
+export const defineCommentFactory: DefineTypeFactoryInterface<
+  OptionalComment,
+  {}
+> = defineTypeFactory;
+
+export type OptionalCommentConnection = {
+  __typename?: 'CommentConnection';
+  /** Contains the nodes in this connection. */
+  edges?: Maybe<OptionalCommentEdge>[] | undefined;
+  /** Pagination data for this connection. */
+  pageInfo?: OptionalPageInfo | undefined;
+};
+
+/**
+ * Define factory for {@link CommentConnection} model.
+ *
+ * @param options
+ * @returns factory {@link CommentConnectionFactoryInterface}
+ */
+export const defineCommentConnectionFactory: DefineTypeFactoryInterface<
+  OptionalCommentConnection,
+  {}
+> = defineTypeFactory;
+
+/** A Relay edge containing a `Comment` and its cursor. */
+export type OptionalCommentEdge = {
+  __typename?: 'CommentEdge';
+  /** A cursor for use in pagination */
+  cursor?: CommentEdge['cursor'] | undefined;
+  /** The item at the end of the edge */
+  node?: Maybe<OptionalComment> | undefined;
+};
+
+/**
+ * Define factory for {@link CommentEdge} model.
+ *
+ * @param options
+ * @returns factory {@link CommentEdgeFactoryInterface}
+ */
+export const defineCommentEdgeFactory: DefineTypeFactoryInterface<
+  OptionalCommentEdge,
+  {}
+> = defineTypeFactory;
+
+export type OptionalCreateCommentInput = {
+  __typename?: 'CreateCommentInput';
+  /** コメントをする対象の作品ID */
+  artworkId?: CreateCommentInput['artworkId'] | undefined;
+  clientMutationId?: CreateCommentInput['clientMutationId'] | undefined;
+  /** コメントの本文 */
+  text?: CreateCommentInput['text'] | undefined;
+};
+
+/**
+ * Define factory for {@link CreateCommentInput} model.
+ *
+ * @param options
+ * @returns factory {@link CreateCommentInputFactoryInterface}
+ */
+export const defineCreateCommentInputFactory: DefineTypeFactoryInterface<
+  OptionalCreateCommentInput,
+  {}
+> = defineTypeFactory;
+
+export type OptionalCreateCommentPayload = {
+  __typename?: 'CreateCommentPayload';
+  clientMutationId?: CreateCommentPayload['clientMutationId'] | undefined;
+  comment?: Maybe<OptionalComment> | undefined;
+};
+
+/**
+ * Define factory for {@link CreateCommentPayload} model.
+ *
+ * @param options
+ * @returns factory {@link CreateCommentPayloadFactoryInterface}
+ */
+export const defineCreateCommentPayloadFactory: DefineTypeFactoryInterface<
+  OptionalCreateCommentPayload,
+  {}
+> = defineTypeFactory;
+
+export type OptionalDeleteArtworkInput = {
+  __typename?: 'DeleteArtworkInput';
+  clientMutationId?: DeleteArtworkInput['clientMutationId'] | undefined;
+  /** 削除対象の作品のID */
+  id?: DeleteArtworkInput['id'] | undefined;
+};
+
+/**
+ * Define factory for {@link DeleteArtworkInput} model.
+ *
+ * @param options
+ * @returns factory {@link DeleteArtworkInputFactoryInterface}
+ */
+export const defineDeleteArtworkInputFactory: DefineTypeFactoryInterface<
+  OptionalDeleteArtworkInput,
+  {}
+> = defineTypeFactory;
+
+export type OptionalDeleteArtworkPayload = {
+  __typename?: 'DeleteArtworkPayload';
+  clientMutationId?: DeleteArtworkPayload['clientMutationId'] | undefined;
+  deletedArtworkId?: DeleteArtworkPayload['deletedArtworkId'] | undefined;
+};
+
+/**
+ * Define factory for {@link DeleteArtworkPayload} model.
+ *
+ * @param options
+ * @returns factory {@link DeleteArtworkPayloadFactoryInterface}
+ */
+export const defineDeleteArtworkPayloadFactory: DefineTypeFactoryInterface<
+  OptionalDeleteArtworkPayload,
+  {}
+> = defineTypeFactory;
+
+export type OptionalIllust = {
+  __typename?: 'Illust';
+  artwork?: Maybe<OptionalArtwork> | undefined;
+  artworkId?: Illust['artworkId'] | undefined;
+  createdAt?: Illust['createdAt'] | undefined;
+  filename?: Illust['filename'] | undefined;
+  /** The ID of the object. */
+  id?: Illust['id'] | undefined;
+  imageUrl?: Illust['imageUrl'] | undefined;
+  thumbnailUrl?: Illust['thumbnailUrl'] | undefined;
+  updatedAt?: Illust['updatedAt'] | undefined;
+  webpUrl?: Illust['webpUrl'] | undefined;
+};
+
+/**
+ * Define factory for {@link Illust} model.
+ *
+ * @param options
+ * @returns factory {@link IllustFactoryInterface}
+ */
+export const defineIllustFactory: DefineTypeFactoryInterface<
+  OptionalIllust,
+  {}
+> = defineTypeFactory;
+
+export type OptionalIllustConnection = {
+  __typename?: 'IllustConnection';
+  /** Contains the nodes in this connection. */
+  edges?: Maybe<OptionalIllustEdge>[] | undefined;
+  /** Pagination data for this connection. */
+  pageInfo?: OptionalPageInfo | undefined;
+};
+
+/**
+ * Define factory for {@link IllustConnection} model.
+ *
+ * @param options
+ * @returns factory {@link IllustConnectionFactoryInterface}
+ */
+export const defineIllustConnectionFactory: DefineTypeFactoryInterface<
+  OptionalIllustConnection,
+  {}
+> = defineTypeFactory;
+
+/** A Relay edge containing a `Illust` and its cursor. */
+export type OptionalIllustEdge = {
+  __typename?: 'IllustEdge';
+  /** A cursor for use in pagination */
+  cursor?: IllustEdge['cursor'] | undefined;
+  /** The item at the end of the edge */
+  node?: Maybe<OptionalIllust> | undefined;
+};
+
+/**
+ * Define factory for {@link IllustEdge} model.
+ *
+ * @param options
+ * @returns factory {@link IllustEdgeFactoryInterface}
+ */
+export const defineIllustEdgeFactory: DefineTypeFactoryInterface<
+  OptionalIllustEdge,
+  {}
+> = defineTypeFactory;
+
+export type OptionalLike = {
+  __typename?: 'Like';
+  account?: Maybe<OptionalAccount> | undefined;
+  accountId?: Like['accountId'] | undefined;
+  artwork?: Maybe<OptionalArtwork> | undefined;
+  artworkId?: Like['artworkId'] | undefined;
+  createdAt?: Like['createdAt'] | undefined;
+  /** The ID of the object. */
+  id?: Like['id'] | undefined;
+  updatedAt?: Like['updatedAt'] | undefined;
+};
+
+/**
+ * Define factory for {@link Like} model.
+ *
+ * @param options
+ * @returns factory {@link LikeFactoryInterface}
+ */
+export const defineLikeFactory: DefineTypeFactoryInterface<
+  OptionalLike,
+  {}
+> = defineTypeFactory;
+
+export type OptionalLikeArtworkInput = {
+  __typename?: 'LikeArtworkInput';
+  /** 「いいね」をする対象の作品ID */
+  artworkId?: LikeArtworkInput['artworkId'] | undefined;
+  clientMutationId?: LikeArtworkInput['clientMutationId'] | undefined;
+};
+
+/**
+ * Define factory for {@link LikeArtworkInput} model.
+ *
+ * @param options
+ * @returns factory {@link LikeArtworkInputFactoryInterface}
+ */
+export const defineLikeArtworkInputFactory: DefineTypeFactoryInterface<
+  OptionalLikeArtworkInput,
+  {}
+> = defineTypeFactory;
+
+export type OptionalLikeArtworkPayload = {
+  __typename?: 'LikeArtworkPayload';
+  clientMutationId?: LikeArtworkPayload['clientMutationId'] | undefined;
+  like?: Maybe<OptionalLike> | undefined;
+};
+
+/**
+ * Define factory for {@link LikeArtworkPayload} model.
+ *
+ * @param options
+ * @returns factory {@link LikeArtworkPayloadFactoryInterface}
+ */
+export const defineLikeArtworkPayloadFactory: DefineTypeFactoryInterface<
+  OptionalLikeArtworkPayload,
+  {}
+> = defineTypeFactory;
+
+export type OptionalLikeConnection = {
+  __typename?: 'LikeConnection';
+  /** Contains the nodes in this connection. */
+  edges?: Maybe<OptionalLikeEdge>[] | undefined;
+  /** Pagination data for this connection. */
+  pageInfo?: OptionalPageInfo | undefined;
+};
+
+/**
+ * Define factory for {@link LikeConnection} model.
+ *
+ * @param options
+ * @returns factory {@link LikeConnectionFactoryInterface}
+ */
+export const defineLikeConnectionFactory: DefineTypeFactoryInterface<
+  OptionalLikeConnection,
+  {}
+> = defineTypeFactory;
+
+/** A Relay edge containing a `Like` and its cursor. */
+export type OptionalLikeEdge = {
+  __typename?: 'LikeEdge';
+  /** A cursor for use in pagination */
+  cursor?: LikeEdge['cursor'] | undefined;
+  /** The item at the end of the edge */
+  node?: Maybe<OptionalLike> | undefined;
+};
+
+/**
+ * Define factory for {@link LikeEdge} model.
+ *
+ * @param options
+ * @returns factory {@link LikeEdgeFactoryInterface}
+ */
+export const defineLikeEdgeFactory: DefineTypeFactoryInterface<
+  OptionalLikeEdge,
+  {}
+> = defineTypeFactory;
+
+export type OptionalMutation = {
+  __typename?: 'Mutation';
+  /** 作品にコメントする */
+  createComment?: Maybe<OptionalCreateCommentPayload> | undefined;
+  /** 作品を削除する */
+  deleteArtwork?: Maybe<OptionalDeleteArtworkPayload> | undefined;
+  /** 作品に「いいね」をする */
+  likeArtwork?: Maybe<OptionalLikeArtworkPayload> | undefined;
+  /** ユーザー情報を更新する */
+  updateAccount?: Maybe<OptionalUpdateAccountPayload> | undefined;
+  /** 作品の情報を更新する */
+  updateArtwork?: Maybe<OptionalUpdateArtworkPayload> | undefined;
+  /** タグの情報を更新する */
+  updateTag?: Maybe<OptionalUpdateTagPayload> | undefined;
+  /** 作品をアップロードする */
+  uploadArtwork?: Maybe<OptionalUploadArtworkPayload> | undefined;
+};
+
+/**
+ * Define factory for {@link Mutation} model.
+ *
+ * @param options
+ * @returns factory {@link MutationFactoryInterface}
+ */
+export const defineMutationFactory: DefineTypeFactoryInterface<
+  OptionalMutation,
+  {}
+> = defineTypeFactory;
+
+/** An object with an ID */
+export type OptionalNode = OptionalAccount | OptionalArtwork | OptionalComment | OptionalIllust | OptionalLike | OptionalTag;
+
+/** The Relay compliant `PageInfo` type, containing data necessary to paginate this connection. */
+export type OptionalPageInfo = {
+  __typename?: 'PageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: PageInfo['endCursor'] | undefined;
+  /** When paginating forwards, are there more items? */
+  hasNextPage?: PageInfo['hasNextPage'] | undefined;
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage?: PageInfo['hasPreviousPage'] | undefined;
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: PageInfo['startCursor'] | undefined;
+};
+
+/**
+ * Define factory for {@link PageInfo} model.
+ *
+ * @param options
+ * @returns factory {@link PageInfoFactoryInterface}
+ */
+export const definePageInfoFactory: DefineTypeFactoryInterface<
+  OptionalPageInfo,
+  {}
+> = defineTypeFactory;
+
+export type OptionalQuery = {
+  __typename?: 'Query';
+  accountByKmcid?: Maybe<OptionalAccount> | undefined;
+  accounts?: Maybe<OptionalAccountConnection> | undefined;
+  activeAccounts?: Maybe<OptionalAccountConnection> | undefined;
+  allSlackChannels?: Maybe<OptionalSlackChannel>[] | undefined;
+  allTags?: Maybe<OptionalTagConnection> | undefined;
+  /** for compatibility */
+  artworkByFolderId?: Maybe<OptionalArtwork> | undefined;
+  artworks?: Maybe<OptionalArtworkConnection> | undefined;
+  node?: Maybe<OptionalNode> | undefined;
+  nodes?: Maybe<OptionalNode>[] | undefined;
+  tagByName?: Maybe<OptionalTag> | undefined;
+  taggedArtworks?: Maybe<OptionalArtworkConnection> | undefined;
+  viewer?: Maybe<OptionalAccount> | undefined;
+};
+
+/**
+ * Define factory for {@link Query} model.
+ *
+ * @param options
+ * @returns factory {@link QueryFactoryInterface}
+ */
+export const defineQueryFactory: DefineTypeFactoryInterface<
+  OptionalQuery,
+  {}
+> = defineTypeFactory;
+
+export type OptionalSlackChannel = {
+  __typename?: 'SlackChannel';
+  id?: SlackChannel['id'] | undefined;
+  name?: SlackChannel['name'] | undefined;
+};
+
+/**
+ * Define factory for {@link SlackChannel} model.
+ *
+ * @param options
+ * @returns factory {@link SlackChannelFactoryInterface}
+ */
+export const defineSlackChannelFactory: DefineTypeFactoryInterface<
+  OptionalSlackChannel,
+  {}
+> = defineTypeFactory;
+
+export type OptionalTag = {
+  __typename?: 'Tag';
+  artworks?: Maybe<OptionalArtworkConnection> | undefined;
+  artworksCount?: Tag['artworksCount'] | undefined;
+  canonicalName?: Tag['canonicalName'] | undefined;
+  createdAt?: Tag['createdAt'] | undefined;
+  editFreezed?: Tag['editFreezed'] | undefined;
+  /** The ID of the object. */
+  id?: Tag['id'] | undefined;
+  name?: Tag['name'] | undefined;
+  updatedAt?: Tag['updatedAt'] | undefined;
+};
+
+/**
+ * Define factory for {@link Tag} model.
+ *
+ * @param options
+ * @returns factory {@link TagFactoryInterface}
+ */
+export const defineTagFactory: DefineTypeFactoryInterface<
+  OptionalTag,
+  {}
+> = defineTypeFactory;
+
+export type OptionalTagConnection = {
+  __typename?: 'TagConnection';
+  /** Contains the nodes in this connection. */
+  edges?: Maybe<OptionalTagEdge>[] | undefined;
+  /** Pagination data for this connection. */
+  pageInfo?: OptionalPageInfo | undefined;
+};
+
+/**
+ * Define factory for {@link TagConnection} model.
+ *
+ * @param options
+ * @returns factory {@link TagConnectionFactoryInterface}
+ */
+export const defineTagConnectionFactory: DefineTypeFactoryInterface<
+  OptionalTagConnection,
+  {}
+> = defineTypeFactory;
+
+/** A Relay edge containing a `Tag` and its cursor. */
+export type OptionalTagEdge = {
+  __typename?: 'TagEdge';
+  /** A cursor for use in pagination */
+  cursor?: TagEdge['cursor'] | undefined;
+  /** The item at the end of the edge */
+  node?: Maybe<OptionalTag> | undefined;
+};
+
+/**
+ * Define factory for {@link TagEdge} model.
+ *
+ * @param options
+ * @returns factory {@link TagEdgeFactoryInterface}
+ */
+export const defineTagEdgeFactory: DefineTypeFactoryInterface<
+  OptionalTagEdge,
+  {}
+> = defineTypeFactory;
+
+export type OptionalTwitterShareOption = {
+  __typename?: 'TwitterShareOption';
+  /** 作品をTwitterに共有するかどうか。falseのときは共有されず、他のフィールドも無視される。 */
+  share?: TwitterShareOption['share'] | undefined;
+  /** Twitterに共有する際の投稿者の表示名。空文字やnullのときはKMCIDが使われる */
+  username?: TwitterShareOption['username'] | undefined;
+};
+
+/**
+ * Define factory for {@link TwitterShareOption} model.
+ *
+ * @param options
+ * @returns factory {@link TwitterShareOptionFactoryInterface}
+ */
+export const defineTwitterShareOptionFactory: DefineTypeFactoryInterface<
+  OptionalTwitterShareOption,
+  {}
+> = defineTypeFactory;
+
+export type OptionalUpdateAccountInput = {
+  __typename?: 'UpdateAccountInput';
+  clientMutationId?: UpdateAccountInput['clientMutationId'] | undefined;
+  name?: UpdateAccountInput['name'] | undefined;
+};
+
+/**
+ * Define factory for {@link UpdateAccountInput} model.
+ *
+ * @param options
+ * @returns factory {@link UpdateAccountInputFactoryInterface}
+ */
+export const defineUpdateAccountInputFactory: DefineTypeFactoryInterface<
+  OptionalUpdateAccountInput,
+  {}
+> = defineTypeFactory;
+
+export type OptionalUpdateAccountPayload = {
+  __typename?: 'UpdateAccountPayload';
+  account?: Maybe<OptionalAccount> | undefined;
+  clientMutationId?: UpdateAccountPayload['clientMutationId'] | undefined;
+};
+
+/**
+ * Define factory for {@link UpdateAccountPayload} model.
+ *
+ * @param options
+ * @returns factory {@link UpdateAccountPayloadFactoryInterface}
+ */
+export const defineUpdateAccountPayloadFactory: DefineTypeFactoryInterface<
+  OptionalUpdateAccountPayload,
+  {}
+> = defineTypeFactory;
+
+export type OptionalUpdateArtworkInput = {
+  __typename?: 'UpdateArtworkInput';
+  /** 更新後の説明文 */
+  caption?: UpdateArtworkInput['caption'] | undefined;
+  clientMutationId?: UpdateArtworkInput['clientMutationId'] | undefined;
+  /** 更新対象の作品のID */
+  id?: UpdateArtworkInput['id'] | undefined;
+  /** 更新後の年齢制限 */
+  rating?: UpdateArtworkInput['rating'] | undefined;
+  /** 更新後のタグ */
+  tags?: UpdateArtworkInput['tags'] | undefined;
+  /** 更新後のタイトル */
+  title?: UpdateArtworkInput['title'] | undefined;
+};
+
+/**
+ * Define factory for {@link UpdateArtworkInput} model.
+ *
+ * @param options
+ * @returns factory {@link UpdateArtworkInputFactoryInterface}
+ */
+export const defineUpdateArtworkInputFactory: DefineTypeFactoryInterface<
+  OptionalUpdateArtworkInput,
+  {}
+> = defineTypeFactory;
+
+export type OptionalUpdateArtworkPayload = {
+  __typename?: 'UpdateArtworkPayload';
+  artwork?: Maybe<OptionalArtwork> | undefined;
+  clientMutationId?: UpdateArtworkPayload['clientMutationId'] | undefined;
+};
+
+/**
+ * Define factory for {@link UpdateArtworkPayload} model.
+ *
+ * @param options
+ * @returns factory {@link UpdateArtworkPayloadFactoryInterface}
+ */
+export const defineUpdateArtworkPayloadFactory: DefineTypeFactoryInterface<
+  OptionalUpdateArtworkPayload,
+  {}
+> = defineTypeFactory;
+
+export type OptionalUpdateTagInput = {
+  __typename?: 'UpdateTagInput';
+  clientMutationId?: UpdateTagInput['clientMutationId'] | undefined;
+  /** 更新対象のタグのID */
+  id?: UpdateTagInput['id'] | undefined;
+  /** 更新後のタグの表記 */
+  name?: UpdateTagInput['name'] | undefined;
+};
+
+/**
+ * Define factory for {@link UpdateTagInput} model.
+ *
+ * @param options
+ * @returns factory {@link UpdateTagInputFactoryInterface}
+ */
+export const defineUpdateTagInputFactory: DefineTypeFactoryInterface<
+  OptionalUpdateTagInput,
+  {}
+> = defineTypeFactory;
+
+export type OptionalUpdateTagPayload = {
+  __typename?: 'UpdateTagPayload';
+  clientMutationId?: UpdateTagPayload['clientMutationId'] | undefined;
+  tag?: Maybe<OptionalTag> | undefined;
+};
+
+/**
+ * Define factory for {@link UpdateTagPayload} model.
+ *
+ * @param options
+ * @returns factory {@link UpdateTagPayloadFactoryInterface}
+ */
+export const defineUpdateTagPayloadFactory: DefineTypeFactoryInterface<
+  OptionalUpdateTagPayload,
+  {}
+> = defineTypeFactory;
+
+export type OptionalUploadArtworkInput = {
+  __typename?: 'UploadArtworkInput';
+  /** 作品の説明文 */
+  caption?: UploadArtworkInput['caption'] | undefined;
+  /** 投稿したことを共有するSlackチャンネルのID */
+  channelId?: UploadArtworkInput['channelId'] | undefined;
+  clientMutationId?: UploadArtworkInput['clientMutationId'] | undefined;
+  /** アップロードする画像 (GIF/PNG/JPEG形式) */
+  files?: UploadArtworkInput['files'] | undefined;
+  /** 更新後の年齢制限 */
+  rating?: UploadArtworkInput['rating'] | undefined;
+  /** 作品をSlackにシェアするかどうか */
+  shareOption?: UploadArtworkInput['shareOption'] | undefined;
+  /** 作品に付けるタグ */
+  tags?: UploadArtworkInput['tags'] | undefined;
+  /** 作品のタイトル */
+  title?: UploadArtworkInput['title'] | undefined;
+  /** Twitterへの共有設定。nullのときは共有しない */
+  twitterShareOption?: Maybe<OptionalTwitterShareOption> | undefined;
+};
+
+/**
+ * Define factory for {@link UploadArtworkInput} model.
+ *
+ * @param options
+ * @returns factory {@link UploadArtworkInputFactoryInterface}
+ */
+export const defineUploadArtworkInputFactory: DefineTypeFactoryInterface<
+  OptionalUploadArtworkInput,
+  {}
+> = defineTypeFactory;
+
+export type OptionalUploadArtworkPayload = {
+  __typename?: 'UploadArtworkPayload';
+  artwork?: Maybe<OptionalArtwork> | undefined;
+  clientMutationId?: UploadArtworkPayload['clientMutationId'] | undefined;
+};
+
+/**
+ * Define factory for {@link UploadArtworkPayload} model.
+ *
+ * @param options
+ * @returns factory {@link UploadArtworkPayloadFactoryInterface}
+ */
+export const defineUploadArtworkPayloadFactory: DefineTypeFactoryInterface<
+  OptionalUploadArtworkPayload,
+  {}
+> = defineTypeFactory;
+

--- a/front/src/mocks/__generated__/types.ts
+++ b/front/src/mocks/__generated__/types.ts
@@ -1,0 +1,625 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  /**
+   * The `DateTime` scalar type represents a DateTime
+   * value as specified by
+   * [iso8601](https://en.wikipedia.org/wiki/ISO_8601).
+   */
+  DateTime: { input: unknown; output: unknown; }
+  /**
+   * Create scalar that ignores normal serialization/deserialization, since
+   * that will be handled by the multipart request spec
+   */
+  Upload: { input: unknown; output: unknown; }
+};
+
+export type Account = Node & {
+  __typename?: 'Account';
+  artworks: Maybe<ArtworkConnection>;
+  artworksCount: Scalars['Int']['output'];
+  comments: Maybe<CommentConnection>;
+  createdAt: Scalars['DateTime']['output'];
+  /** The ID of the object. */
+  id: Scalars['ID']['output'];
+  /** ログインユーザーかどうか */
+  isYou: Scalars['Boolean']['output'];
+  kmcid: Scalars['String']['output'];
+  lastLoggedIn: Scalars['DateTime']['output'];
+  likes: Maybe<LikeConnection>;
+  name: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+export type AccountArtworksArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type AccountCommentsArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type AccountLikesArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type AccountConnection = {
+  __typename?: 'AccountConnection';
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<AccountEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+};
+
+/** A Relay edge containing a `Account` and its cursor. */
+export type AccountEdge = {
+  __typename?: 'AccountEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: Maybe<Account>;
+};
+
+/** An enumeration. */
+export type AccountSortEnum =
+  | 'ARTWORKS_COUNT_ASC'
+  | 'ARTWORKS_COUNT_DESC'
+  | 'CREATED_AT_ASC'
+  | 'CREATED_AT_DESC'
+  | 'ID_ASC'
+  | 'ID_DESC'
+  | 'KMCID_ASC'
+  | 'KMCID_DESC'
+  | 'LAST_LOGGED_IN_ASC'
+  | 'LAST_LOGGED_IN_DESC'
+  | 'NAME_ASC'
+  | 'NAME_DESC'
+  | 'UPDATED_AT_ASC'
+  | 'UPDATED_AT_DESC';
+
+export type Artwork = Node & {
+  __typename?: 'Artwork';
+  account: Maybe<Account>;
+  accountId: Scalars['Int']['output'];
+  caption: Scalars['String']['output'];
+  comments: Maybe<CommentConnection>;
+  createdAt: Scalars['DateTime']['output'];
+  /** 作品の情報を編集できるかどうかを返す */
+  editable: Scalars['Boolean']['output'];
+  /** The ID of the object. */
+  id: Scalars['ID']['output'];
+  illusts: Maybe<IllustConnection>;
+  likes: Maybe<LikeConnection>;
+  /** この作品より1つ新しい、同じユーザーの作品を返す */
+  nextArtwork: Maybe<Artwork>;
+  nsfw: Scalars['Boolean']['output'];
+  /** この作品より1つ古い、同じユーザーの作品を返す */
+  previousArtwork: Maybe<Artwork>;
+  rating: ArtworkRatingEnum;
+  tags: Maybe<TagConnection>;
+  title: Scalars['String']['output'];
+  topIllust: Maybe<Illust>;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+export type ArtworkCommentsArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ArtworkIllustsArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ArtworkLikesArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type ArtworkTagsArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ArtworkConnection = {
+  __typename?: 'ArtworkConnection';
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<ArtworkEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+};
+
+/** A Relay edge containing a `Artwork` and its cursor. */
+export type ArtworkEdge = {
+  __typename?: 'ArtworkEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: Maybe<Artwork>;
+};
+
+/** 作品の年齢制限 (全年齢/R-18/R-18G) を表すenum */
+export type ArtworkRatingEnum =
+  | 'r_18'
+  | 'r_18g'
+  | 'safe';
+
+/** An enumeration. */
+export type ArtworkSortEnum =
+  | 'ACCOUNT_ID_ASC'
+  | 'ACCOUNT_ID_DESC'
+  | 'CAPTION_ASC'
+  | 'CAPTION_DESC'
+  | 'CREATED_AT_ASC'
+  | 'CREATED_AT_DESC'
+  | 'ID_ASC'
+  | 'ID_DESC'
+  | 'TITLE_ASC'
+  | 'TITLE_DESC'
+  | 'UPDATED_AT_ASC'
+  | 'UPDATED_AT_DESC';
+
+export type Comment = Node & {
+  __typename?: 'Comment';
+  account: Maybe<Account>;
+  accountId: Scalars['Int']['output'];
+  artwork: Maybe<Artwork>;
+  artworkId: Scalars['Int']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  /** The ID of the object. */
+  id: Scalars['ID']['output'];
+  text: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+export type CommentConnection = {
+  __typename?: 'CommentConnection';
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<CommentEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+};
+
+/** A Relay edge containing a `Comment` and its cursor. */
+export type CommentEdge = {
+  __typename?: 'CommentEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: Maybe<Comment>;
+};
+
+export type CreateCommentInput = {
+  /** コメントをする対象の作品ID */
+  artworkId: Scalars['ID']['input'];
+  clientMutationId: InputMaybe<Scalars['String']['input']>;
+  /** コメントの本文 */
+  text: Scalars['String']['input'];
+};
+
+export type CreateCommentPayload = {
+  __typename?: 'CreateCommentPayload';
+  clientMutationId: Maybe<Scalars['String']['output']>;
+  comment: Maybe<Comment>;
+};
+
+export type DeleteArtworkInput = {
+  clientMutationId: InputMaybe<Scalars['String']['input']>;
+  /** 削除対象の作品のID */
+  id: Scalars['ID']['input'];
+};
+
+export type DeleteArtworkPayload = {
+  __typename?: 'DeleteArtworkPayload';
+  clientMutationId: Maybe<Scalars['String']['output']>;
+  deletedArtworkId: Maybe<Scalars['ID']['output']>;
+};
+
+export type Illust = Node & {
+  __typename?: 'Illust';
+  artwork: Maybe<Artwork>;
+  artworkId: Scalars['Int']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  filename: Scalars['String']['output'];
+  /** The ID of the object. */
+  id: Scalars['ID']['output'];
+  imageUrl: Scalars['String']['output'];
+  thumbnailUrl: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  webpUrl: Scalars['String']['output'];
+};
+
+export type IllustConnection = {
+  __typename?: 'IllustConnection';
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<IllustEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+};
+
+/** A Relay edge containing a `Illust` and its cursor. */
+export type IllustEdge = {
+  __typename?: 'IllustEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: Maybe<Illust>;
+};
+
+export type Like = Node & {
+  __typename?: 'Like';
+  account: Maybe<Account>;
+  accountId: Scalars['Int']['output'];
+  artwork: Maybe<Artwork>;
+  artworkId: Scalars['Int']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  /** The ID of the object. */
+  id: Scalars['ID']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+export type LikeArtworkInput = {
+  /** 「いいね」をする対象の作品ID */
+  artworkId: Scalars['ID']['input'];
+  clientMutationId: InputMaybe<Scalars['String']['input']>;
+};
+
+export type LikeArtworkPayload = {
+  __typename?: 'LikeArtworkPayload';
+  clientMutationId: Maybe<Scalars['String']['output']>;
+  like: Maybe<Like>;
+};
+
+export type LikeConnection = {
+  __typename?: 'LikeConnection';
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<LikeEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+};
+
+/** A Relay edge containing a `Like` and its cursor. */
+export type LikeEdge = {
+  __typename?: 'LikeEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: Maybe<Like>;
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** 作品にコメントする */
+  createComment: Maybe<CreateCommentPayload>;
+  /** 作品を削除する */
+  deleteArtwork: Maybe<DeleteArtworkPayload>;
+  /** 作品に「いいね」をする */
+  likeArtwork: Maybe<LikeArtworkPayload>;
+  /** ユーザー情報を更新する */
+  updateAccount: Maybe<UpdateAccountPayload>;
+  /** 作品の情報を更新する */
+  updateArtwork: Maybe<UpdateArtworkPayload>;
+  /** タグの情報を更新する */
+  updateTag: Maybe<UpdateTagPayload>;
+  /** 作品をアップロードする */
+  uploadArtwork: Maybe<UploadArtworkPayload>;
+};
+
+
+export type MutationCreateCommentArgs = {
+  input: CreateCommentInput;
+};
+
+
+export type MutationDeleteArtworkArgs = {
+  input: DeleteArtworkInput;
+};
+
+
+export type MutationLikeArtworkArgs = {
+  input: LikeArtworkInput;
+};
+
+
+export type MutationUpdateAccountArgs = {
+  input: UpdateAccountInput;
+};
+
+
+export type MutationUpdateArtworkArgs = {
+  input: UpdateArtworkInput;
+};
+
+
+export type MutationUpdateTagArgs = {
+  input: UpdateTagInput;
+};
+
+
+export type MutationUploadArtworkArgs = {
+  input: UploadArtworkInput;
+};
+
+/** An object with an ID */
+export type Node = {
+  /** The ID of the object. */
+  id: Scalars['ID']['output'];
+};
+
+/** The Relay compliant `PageInfo` type, containing data necessary to paginate this connection. */
+export type PageInfo = {
+  __typename?: 'PageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, the cursor to continue. */
+  startCursor: Maybe<Scalars['String']['output']>;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  accountByKmcid: Maybe<Account>;
+  accounts: Maybe<AccountConnection>;
+  activeAccounts: Maybe<AccountConnection>;
+  allSlackChannels: Array<Maybe<SlackChannel>>;
+  allTags: Maybe<TagConnection>;
+  /** for compatibility */
+  artworkByFolderId: Maybe<Artwork>;
+  artworks: Maybe<ArtworkConnection>;
+  node: Maybe<Node>;
+  nodes: Array<Maybe<Node>>;
+  tagByName: Maybe<Tag>;
+  taggedArtworks: Maybe<ArtworkConnection>;
+  viewer: Maybe<Account>;
+};
+
+
+export type QueryAccountByKmcidArgs = {
+  kmcid: Scalars['String']['input'];
+};
+
+
+export type QueryAccountsArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+  sort: InputMaybe<Array<InputMaybe<AccountSortEnum>>>;
+};
+
+
+export type QueryActiveAccountsArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+  sort: InputMaybe<Array<InputMaybe<AccountSortEnum>>>;
+};
+
+
+export type QueryAllTagsArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+  sort: InputMaybe<Array<InputMaybe<TagSortEnum>>>;
+};
+
+
+export type QueryArtworkByFolderIdArgs = {
+  folderId: Scalars['Int']['input'];
+};
+
+
+export type QueryArtworksArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+  rating: InputMaybe<Array<ArtworkRatingEnum>>;
+  sort: InputMaybe<Array<InputMaybe<ArtworkSortEnum>>>;
+};
+
+
+export type QueryNodeArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryNodesArgs = {
+  ids: Array<Scalars['ID']['input']>;
+};
+
+
+export type QueryTagByNameArgs = {
+  name: Scalars['String']['input'];
+};
+
+
+export type QueryTaggedArtworksArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+  sort: InputMaybe<Array<InputMaybe<ArtworkSortEnum>>>;
+  tag: Scalars['String']['input'];
+};
+
+export type SlackChannel = {
+  __typename?: 'SlackChannel';
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+};
+
+/** 画像をアップロードする際にSlackに共有するかどうかを表すenum */
+export type SlackShareOptionEnum =
+  | 'NONE'
+  | 'SHARE_TO_SLACK'
+  | 'SHARE_TO_SLACK_WITH_IMAGE';
+
+export type Tag = Node & {
+  __typename?: 'Tag';
+  artworks: Maybe<ArtworkConnection>;
+  artworksCount: Scalars['Int']['output'];
+  canonicalName: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  editFreezed: Scalars['Boolean']['output'];
+  /** The ID of the object. */
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+export type TagArtworksArgs = {
+  after: InputMaybe<Scalars['String']['input']>;
+  before: InputMaybe<Scalars['String']['input']>;
+  first: InputMaybe<Scalars['Int']['input']>;
+  last: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type TagConnection = {
+  __typename?: 'TagConnection';
+  /** Contains the nodes in this connection. */
+  edges: Array<Maybe<TagEdge>>;
+  /** Pagination data for this connection. */
+  pageInfo: PageInfo;
+};
+
+/** A Relay edge containing a `Tag` and its cursor. */
+export type TagEdge = {
+  __typename?: 'TagEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: Maybe<Tag>;
+};
+
+/** An enumeration. */
+export type TagSortEnum =
+  | 'ARTWORKS_COUNT_ASC'
+  | 'ARTWORKS_COUNT_DESC'
+  | 'CANONICAL_NAME_ASC'
+  | 'CANONICAL_NAME_DESC'
+  | 'CREATED_AT_ASC'
+  | 'CREATED_AT_DESC'
+  | 'EDIT_FREEZED_ASC'
+  | 'EDIT_FREEZED_DESC'
+  | 'ID_ASC'
+  | 'ID_DESC'
+  | 'NAME_ASC'
+  | 'NAME_DESC'
+  | 'UPDATED_AT_ASC'
+  | 'UPDATED_AT_DESC';
+
+export type TwitterShareOption = {
+  /** 作品をTwitterに共有するかどうか。falseのときは共有されず、他のフィールドも無視される。 */
+  share: Scalars['Boolean']['input'];
+  /** Twitterに共有する際の投稿者の表示名。空文字やnullのときはKMCIDが使われる */
+  username: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateAccountInput = {
+  clientMutationId: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+};
+
+export type UpdateAccountPayload = {
+  __typename?: 'UpdateAccountPayload';
+  account: Maybe<Account>;
+  clientMutationId: Maybe<Scalars['String']['output']>;
+};
+
+export type UpdateArtworkInput = {
+  /** 更新後の説明文 */
+  caption: Scalars['String']['input'];
+  clientMutationId: InputMaybe<Scalars['String']['input']>;
+  /** 更新対象の作品のID */
+  id: Scalars['ID']['input'];
+  /** 更新後の年齢制限 */
+  rating: InputMaybe<ArtworkRatingEnum>;
+  /** 更新後のタグ */
+  tags: Array<Scalars['String']['input']>;
+  /** 更新後のタイトル */
+  title: Scalars['String']['input'];
+};
+
+export type UpdateArtworkPayload = {
+  __typename?: 'UpdateArtworkPayload';
+  artwork: Maybe<Artwork>;
+  clientMutationId: Maybe<Scalars['String']['output']>;
+};
+
+export type UpdateTagInput = {
+  clientMutationId: InputMaybe<Scalars['String']['input']>;
+  /** 更新対象のタグのID */
+  id: Scalars['ID']['input'];
+  /** 更新後のタグの表記 */
+  name: Scalars['String']['input'];
+};
+
+export type UpdateTagPayload = {
+  __typename?: 'UpdateTagPayload';
+  clientMutationId: Maybe<Scalars['String']['output']>;
+  tag: Maybe<Tag>;
+};
+
+export type UploadArtworkInput = {
+  /** 作品の説明文 */
+  caption: Scalars['String']['input'];
+  /** 投稿したことを共有するSlackチャンネルのID */
+  channelId: InputMaybe<Scalars['String']['input']>;
+  clientMutationId: InputMaybe<Scalars['String']['input']>;
+  /** アップロードする画像 (GIF/PNG/JPEG形式) */
+  files: Array<Scalars['Upload']['input']>;
+  /** 更新後の年齢制限 */
+  rating: ArtworkRatingEnum;
+  /** 作品をSlackにシェアするかどうか */
+  shareOption: InputMaybe<SlackShareOptionEnum>;
+  /** 作品に付けるタグ */
+  tags: Array<Scalars['String']['input']>;
+  /** 作品のタイトル */
+  title: Scalars['String']['input'];
+  /** Twitterへの共有設定。nullのときは共有しない */
+  twitterShareOption: InputMaybe<TwitterShareOption>;
+};
+
+export type UploadArtworkPayload = {
+  __typename?: 'UploadArtworkPayload';
+  artwork: Maybe<Artwork>;
+  clientMutationId: Maybe<Scalars['String']['output']>;
+};

--- a/front/src/mocks/browser.ts
+++ b/front/src/mocks/browser.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from "msw/browser";
+
+import { handlers } from "./handlers";
+
+export const worker = setupWorker(...handlers);

--- a/front/src/mocks/db.ts
+++ b/front/src/mocks/db.ts
@@ -16,24 +16,9 @@ export async function getDb() {
 
 async function buildDb() {
   const [account0, account1, account2] = await Promise.all([
-    AccountFactory.build({
-      kmcid: "testuser",
-      name: "テストユーザー",
-      isYou: true as boolean,
-      artworksCount: 3,
-    }),
-    AccountFactory.build({
-      kmcid: "artist2",
-      name: "アーティスト2",
-      isYou: false as boolean,
-      artworksCount: 5,
-    }),
-    AccountFactory.build({
-      kmcid: "creator3",
-      name: "クリエイター3",
-      isYou: false as boolean,
-      artworksCount: 2,
-    }),
+    AccountFactory.build({ kmcid: "testuser", name: "テストユーザー", isYou: true, artworksCount: 3 }),
+    AccountFactory.build({ kmcid: "artist2", name: "アーティスト2", isYou: false, artworksCount: 5 }),
+    AccountFactory.build({ kmcid: "creator3", name: "クリエイター3", isYou: false, artworksCount: 2 }),
   ]);
 
   const [illust0, illust1, illust2, illust3] = await Promise.all([
@@ -45,11 +30,7 @@ async function buildDb() {
 
   const [tag0, tag1, tag2] = await Promise.all([
     TagFactory.build({ name: "風景", canonicalName: "風景", artworksCount: 2 }),
-    TagFactory.build({
-      name: "キャラクター",
-      canonicalName: "キャラクター",
-      artworksCount: 1,
-    }),
+    TagFactory.build({ name: "キャラクター", canonicalName: "キャラクター", artworksCount: 1 }),
     TagFactory.build({ name: "抽象", canonicalName: "抽象", artworksCount: 1 }),
   ]);
 
@@ -61,20 +42,14 @@ async function buildDb() {
 
   const emptyLikes = {
     edges: [] as never[],
-    pageInfo: {
-      hasNextPage: false,
-      hasPreviousPage: false,
-      startCursor: null,
-      endCursor: null,
-    },
+    pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: null, endCursor: null },
   };
 
-  // 各アートワークのベースを先に構築し、prev/next は後から付加する
   const [base0, base1, base2] = await Promise.all([
     ArtworkFactory.build({
       title: "テスト作品1",
       caption: "これはテスト用の作品です。",
-      editable: true as boolean,
+      editable: true,
       account: account0,
       topIllust: illust0,
       illusts: { edges: [{ node: illust0 }, { node: illust1 }] },
@@ -88,49 +63,30 @@ async function buildDb() {
     ArtworkFactory.build({
       title: "テスト作品2",
       caption: "二番目のテスト作品です。",
-      editable: false as boolean,
+      editable: false,
       account: account1,
       topIllust: illust2,
       illusts: { edges: [{ node: illust2 }] },
       tags: { edges: [{ node: tag0 }, { node: tag2 }] },
       likes: emptyLikes,
-      comments: {
-        edges: [],
-        pageInfo: { hasPreviousPage: false, startCursor: null },
-      },
+      comments: { edges: [], pageInfo: { hasPreviousPage: false, startCursor: null } },
     }),
     ArtworkFactory.build({
       title: "テスト作品3",
       caption: "三番目の作品。",
-      editable: true as boolean,
+      editable: true,
       account: account0,
       topIllust: illust3,
       illusts: { edges: [{ node: illust3 }] },
       tags: { edges: [{ node: tag1 }] },
       likes: emptyLikes,
-      comments: {
-        edges: [],
-        pageInfo: { hasPreviousPage: false, startCursor: null },
-      },
+      comments: { edges: [], pageInfo: { hasPreviousPage: false, startCursor: null } },
     }),
   ]);
 
-  const pickArtwork = (b: typeof base0) => ({
-    id: b.id,
-    title: b.title,
-    nsfw: b.nsfw,
-    topIllust: b.topIllust
-      ? { id: b.topIllust.id, thumbnailUrl: b.topIllust.thumbnailUrl }
-      : null,
-  });
-
   const artworks = [
     { ...base0, previousArtwork: null, nextArtwork: pickArtwork(base1) },
-    {
-      ...base1,
-      previousArtwork: pickArtwork(base0),
-      nextArtwork: pickArtwork(base2),
-    },
+    { ...base1, previousArtwork: pickArtwork(base0), nextArtwork: pickArtwork(base2) },
     { ...base2, previousArtwork: pickArtwork(base1), nextArtwork: null },
   ];
 
@@ -139,6 +95,24 @@ async function buildDb() {
     illusts: [illust0, illust1, illust2, illust3],
     tags: [tag0, tag1, tag2],
     artworks,
+  };
+}
+
+// pickArtwork は使うフィールドだけを宣言した構造型で受け取ることで
+// リテラル型の相違 (editable: true vs false など) に依存しない
+function pickArtwork(b: {
+  id?: string;
+  title?: string;
+  nsfw?: boolean;
+  topIllust?: { id?: string; thumbnailUrl?: string } | null;
+}) {
+  return {
+    id: b.id,
+    title: b.title,
+    nsfw: b.nsfw,
+    topIllust: b.topIllust
+      ? { id: b.topIllust.id, thumbnailUrl: b.topIllust.thumbnailUrl }
+      : null,
   };
 }
 

--- a/front/src/mocks/db.ts
+++ b/front/src/mocks/db.ts
@@ -1,0 +1,157 @@
+import {
+  AccountFactory,
+  ArtworkFactory,
+  CommentFactory,
+  IllustFactory,
+  TagFactory,
+} from "./factories";
+
+// buildDb の返り値から型を推論させる
+// eslint-disable-next-line @typescript-eslint/no-use-before-define
+let _db: Awaited<ReturnType<typeof buildDb>> | null = null;
+
+export async function getDb() {
+  if (_db) return _db;
+  _db = await buildDb();
+  return _db;
+}
+
+async function buildDb() {
+  const [account0, account1, account2] = await Promise.all([
+    AccountFactory.build({
+      kmcid: "testuser",
+      name: "テストユーザー",
+      isYou: true as boolean,
+      artworksCount: 3,
+    }),
+    AccountFactory.build({
+      kmcid: "artist2",
+      name: "アーティスト2",
+      isYou: false as boolean,
+      artworksCount: 5,
+    }),
+    AccountFactory.build({
+      kmcid: "creator3",
+      name: "クリエイター3",
+      isYou: false as boolean,
+      artworksCount: 2,
+    }),
+  ]);
+
+  const [illust0, illust1, illust2, illust3] = await Promise.all([
+    IllustFactory.build(),
+    IllustFactory.build(),
+    IllustFactory.build(),
+    IllustFactory.build(),
+  ]);
+
+  const [tag0, tag1, tag2] = await Promise.all([
+    TagFactory.build({ name: "風景", canonicalName: "風景", artworksCount: 2 }),
+    TagFactory.build({
+      name: "キャラクター",
+      canonicalName: "キャラクター",
+      artworksCount: 1,
+    }),
+    TagFactory.build({ name: "抽象", canonicalName: "抽象", artworksCount: 1 }),
+  ]);
+
+  const comment0 = await CommentFactory.build({
+    text: "素晴らしい作品ですね！",
+    account: account1,
+    accountId: 1,
+  });
+
+  const emptyLikes = {
+    edges: [] as never[],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  };
+
+  // 各アートワークのベースを先に構築し、prev/next は後から付加する
+  const [base0, base1, base2] = await Promise.all([
+    ArtworkFactory.build({
+      title: "テスト作品1",
+      caption: "これはテスト用の作品です。",
+      editable: true as boolean,
+      account: account0,
+      topIllust: illust0,
+      illusts: { edges: [{ node: illust0 }, { node: illust1 }] },
+      tags: { edges: [{ node: tag0 }, { node: tag1 }] },
+      likes: emptyLikes,
+      comments: {
+        edges: [{ node: comment0, cursor: btoa("0") }],
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+      },
+    }),
+    ArtworkFactory.build({
+      title: "テスト作品2",
+      caption: "二番目のテスト作品です。",
+      editable: false as boolean,
+      account: account1,
+      topIllust: illust2,
+      illusts: { edges: [{ node: illust2 }] },
+      tags: { edges: [{ node: tag0 }, { node: tag2 }] },
+      likes: emptyLikes,
+      comments: {
+        edges: [],
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+      },
+    }),
+    ArtworkFactory.build({
+      title: "テスト作品3",
+      caption: "三番目の作品。",
+      editable: true as boolean,
+      account: account0,
+      topIllust: illust3,
+      illusts: { edges: [{ node: illust3 }] },
+      tags: { edges: [{ node: tag1 }] },
+      likes: emptyLikes,
+      comments: {
+        edges: [],
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+      },
+    }),
+  ]);
+
+  const pickArtwork = (b: typeof base0) => ({
+    id: b.id,
+    title: b.title,
+    nsfw: b.nsfw,
+    topIllust: b.topIllust
+      ? { id: b.topIllust.id, thumbnailUrl: b.topIllust.thumbnailUrl }
+      : null,
+  });
+
+  const artworks = [
+    { ...base0, previousArtwork: null, nextArtwork: pickArtwork(base1) },
+    {
+      ...base1,
+      previousArtwork: pickArtwork(base0),
+      nextArtwork: pickArtwork(base2),
+    },
+    { ...base2, previousArtwork: pickArtwork(base1), nextArtwork: null },
+  ];
+
+  return {
+    accounts: [account0, account1, account2],
+    illusts: [illust0, illust1, illust2, illust3],
+    tags: [tag0, tag1, tag2],
+    artworks,
+  };
+}
+
+export function toConnection<T>(nodes: T[]) {
+  return {
+    edges: nodes.map((node, i) => ({ node, cursor: btoa(String(i)) })),
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: nodes.length > 0 ? btoa("0") : null,
+      endCursor: nodes.length > 0 ? btoa(String(nodes.length - 1)) : null,
+    },
+  };
+}

--- a/front/src/mocks/db.ts
+++ b/front/src/mocks/db.ts
@@ -6,8 +6,6 @@ import {
   TagFactory,
 } from "./factories";
 
-// buildDb の返り値から型を推論させる
-// eslint-disable-next-line @typescript-eslint/no-use-before-define
 let _db: Awaited<ReturnType<typeof buildDb>> | null = null;
 
 export async function getDb() {

--- a/front/src/mocks/factories.ts
+++ b/front/src/mocks/factories.ts
@@ -1,0 +1,100 @@
+import {
+  defineAccountFactory,
+  defineArtworkFactory,
+  defineCommentFactory,
+  defineIllustFactory,
+  defineLikeFactory,
+  defineTagFactory,
+  dynamic,
+} from "./__generated__/fabbrica";
+
+export const AccountFactory = defineAccountFactory({
+  defaultFields: {
+    __typename: "Account",
+    id: dynamic(({ seq }) => btoa(`Account:${seq}`)),
+    kmcid: dynamic(({ seq }) => `user${seq}`),
+    name: dynamic(({ seq }) => `ユーザー${seq}`),
+    artworksCount: 0,
+    isYou: false,
+    lastLoggedIn: "2024-01-01T00:00:00",
+    createdAt: "2023-01-01T00:00:00",
+    updatedAt: "2024-01-01T00:00:00",
+  },
+});
+
+export const IllustFactory = defineIllustFactory({
+  defaultFields: {
+    __typename: "Illust",
+    id: dynamic(({ seq }) => btoa(`Illust:${seq}`)),
+    artworkId: dynamic(({ seq }) => seq),
+    filename: dynamic(({ seq }) => `illust${seq}.jpg`),
+    imageUrl: dynamic(
+      ({ seq }) => `https://placehold.jp/800x600.png?text=Illust${seq}`
+    ),
+    thumbnailUrl: dynamic(
+      ({ seq }) => `https://placehold.jp/300x200.png?text=Illust${seq}`
+    ),
+    webpUrl: dynamic(
+      ({ seq }) => `https://placehold.jp/800x600.png?text=Illust${seq}`
+    ),
+    createdAt: "2024-01-10T00:00:00",
+    updatedAt: "2024-01-10T00:00:00",
+  },
+});
+
+export const TagFactory = defineTagFactory({
+  defaultFields: {
+    __typename: "Tag",
+    id: dynamic(({ seq }) => btoa(`Tag:${seq}`)),
+    name: dynamic(({ seq }) => `タグ${seq}`),
+    canonicalName: dynamic(({ seq }) => `タグ${seq}`),
+    artworksCount: 1,
+    editFreezed: false,
+  },
+});
+
+export const CommentFactory = defineCommentFactory({
+  defaultFields: {
+    __typename: "Comment",
+    id: dynamic(({ seq }) => btoa(`Comment:${seq}`)),
+    artworkId: 1,
+    accountId: 1,
+    text: dynamic(({ seq }) => `テストコメント${seq}`),
+    createdAt: "2024-01-11T00:00:00",
+    updatedAt: "2024-01-11T00:00:00",
+  },
+});
+
+export const LikeFactory = defineLikeFactory({
+  defaultFields: {
+    __typename: "Like",
+    id: dynamic(({ seq }) => btoa(`Like:${seq}`)),
+    artworkId: 1,
+    accountId: 1,
+    createdAt: "2024-01-11T00:00:00",
+    updatedAt: "2024-01-11T00:00:00",
+  },
+});
+
+export const ArtworkFactory = defineArtworkFactory({
+  defaultFields: {
+    __typename: "Artwork",
+    id: dynamic(({ seq }) => btoa(`Artwork:${seq}`)),
+    accountId: 1,
+    title: dynamic(({ seq }) => `テスト作品${seq}`),
+    caption: dynamic(({ seq }) => `作品${seq}のキャプション`),
+    rating: "safe",
+    nsfw: false,
+    editable: true,
+    createdAt: "2024-01-10T00:00:00",
+    updatedAt: "2024-01-10T00:00:00",
+    nextArtwork: undefined,
+    previousArtwork: undefined,
+    topIllust: undefined,
+    illusts: undefined,
+    tags: undefined,
+    likes: undefined,
+    comments: undefined,
+    account: undefined,
+  },
+});

--- a/front/src/mocks/factories.ts
+++ b/front/src/mocks/factories.ts
@@ -28,15 +28,9 @@ export const IllustFactory = defineIllustFactory({
     id: dynamic(({ seq }) => btoa(`Illust:${seq}`)),
     artworkId: dynamic(({ seq }) => seq),
     filename: dynamic(({ seq }) => `illust${seq}.jpg`),
-    imageUrl: dynamic(
-      ({ seq }) => `https://placehold.jp/800x600.png?text=Illust${seq}`
-    ),
-    thumbnailUrl: dynamic(
-      ({ seq }) => `https://placehold.jp/300x200.png?text=Illust${seq}`
-    ),
-    webpUrl: dynamic(
-      ({ seq }) => `https://placehold.jp/800x600.png?text=Illust${seq}`
-    ),
+    imageUrl: "/mocks/placeholder.svg",
+    thumbnailUrl: "/mocks/placeholder.svg",
+    webpUrl: "/mocks/placeholder.svg",
     createdAt: "2024-01-10T00:00:00",
     updatedAt: "2024-01-10T00:00:00",
   },

--- a/front/src/mocks/handlers.ts
+++ b/front/src/mocks/handlers.ts
@@ -1,0 +1,201 @@
+import { graphql, HttpResponse } from "msw";
+
+import { CommentFactory, LikeFactory } from "./factories";
+import { getDb, toConnection } from "./db";
+
+export const handlers = [
+  graphql.query("IndexQuery", async () => {
+    const { accounts, artworks } = await getDb();
+    return HttpResponse.json({
+      data: {
+        activeAccounts: toConnection(accounts),
+        safeArtworks: toConnection(artworks.filter((a) => a.rating === "safe")),
+      },
+    });
+  }),
+
+  graphql.query("ArtworkDetailQuery", async ({ variables }) => {
+    const { artworks } = await getDb();
+    const artwork = artworks.find((a) => a.id === variables.id) ?? null;
+    return HttpResponse.json({
+      data: {
+        artworkWithBidirectional: artwork
+          ? { ...artwork, artworkId: artwork.id }
+          : null,
+      },
+    });
+  }),
+
+  graphql.query("UserDetailQuery", async ({ variables }) => {
+    const { accounts, artworks } = await getDb();
+    const user = accounts.find((a) => a.kmcid === variables.kmcid) ?? null;
+    if (!user) return HttpResponse.json({ data: { user: null } });
+    const userArtworks = artworks.filter(
+      (a) => a.account?.kmcid === variables.kmcid
+    );
+    return HttpResponse.json({
+      data: {
+        user: { ...user, artworks: toConnection(userArtworks) },
+      },
+    });
+  }),
+
+  graphql.query("RecentArtworksQuery", async ({ variables }) => {
+    const { artworks } = await getDb();
+    const ratings: string[] = variables.rating ?? ["safe"];
+    return HttpResponse.json({
+      data: {
+        artworks: toConnection(artworks.filter((a) => ratings.includes(a.rating ?? ""))),
+      },
+    });
+  }),
+
+  graphql.query("ArtworkListPaginationQuery", async ({ variables }) => {
+    const { artworks } = await getDb();
+    const ratings: string[] = variables.rating ?? ["safe"];
+    return HttpResponse.json({
+      data: {
+        artworks: toConnection(artworks.filter((a) => ratings.includes(a.rating ?? ""))),
+      },
+    });
+  }),
+
+  graphql.query("RecentArtworkListPaginationQuery", async ({ variables }) => {
+    const { artworks } = await getDb();
+    const ratings: string[] = variables.rating ?? ["safe"];
+    return HttpResponse.json({
+      data: {
+        artworks: toConnection(artworks.filter((a) => ratings.includes(a.rating ?? ""))),
+      },
+    });
+  }),
+
+  graphql.query("TagsQuery", async () => {
+    const { tags } = await getDb();
+    return HttpResponse.json({
+      data: { allTags: toConnection(tags) },
+    });
+  }),
+
+  graphql.query("TaggedArtworksQuery", async ({ variables }) => {
+    const { artworks, tags } = await getDb();
+    const tag = tags.find((t) => t.name === variables.tag) ?? null;
+    const tagged = tag
+      ? artworks.filter((a) =>
+          a.tags?.edges?.some((e) => e?.node?.name === variables.tag)
+        )
+      : [];
+    return HttpResponse.json({
+      data: {
+        tagByName: tag,
+        taggedArtworks: toConnection(tagged),
+      },
+    });
+  }),
+
+  graphql.query("RedirectToMyPageQuery", async () => {
+    const { accounts } = await getDb();
+    return HttpResponse.json({
+      data: { viewer: { kmcid: accounts[0].kmcid } },
+    });
+  }),
+
+  graphql.query("UploadArtworkQuery", async () => {
+    const { accounts } = await getDb();
+    return HttpResponse.json({
+      data: { viewer: { kmcid: accounts[0].kmcid } },
+    });
+  }),
+
+  graphql.query("RedirectFolderToArtworkQuery", async () => {
+    const { artworks } = await getDb();
+    return HttpResponse.json({
+      data: { artworkByFolderId: { id: artworks[0].id } },
+    });
+  }),
+
+  graphql.mutation("UploadArtworkMutation", async () => {
+    const { accounts } = await getDb();
+    return HttpResponse.json({
+      data: {
+        uploadArtwork: {
+          artwork: {
+            id: btoa("Artwork:99"),
+            title: "アップロードされた作品",
+            account: accounts[0],
+          },
+        },
+      },
+    });
+  }),
+
+  graphql.mutation("UpdateArtworkMutation", async ({ variables }) => {
+    const { artworks } = await getDb();
+    const artwork =
+      artworks.find((a) => a.id === variables.input?.id) ?? artworks[0];
+    return HttpResponse.json({
+      data: { updateArtwork: { artwork } },
+    });
+  }),
+
+  graphql.mutation("DeleteArtworkMutation", ({ variables }) => {
+    return HttpResponse.json({
+      data: {
+        deleteArtwork: { deletedArtworkId: variables.input?.id ?? null },
+      },
+    });
+  }),
+
+  graphql.mutation("CreateCommentMutation", async ({ variables }) => {
+    const { accounts } = await getDb();
+    const comment = await CommentFactory.build({
+      text: variables.input?.text ?? "",
+      account: accounts[0],
+    });
+    return HttpResponse.json({
+      data: { createComment: { comment } },
+    });
+  }),
+
+  graphql.mutation("LikeArtworkMutation", async () => {
+    const { accounts } = await getDb();
+    const like = await LikeFactory.build({
+      account: { id: accounts[0].id, kmcid: accounts[0].kmcid },
+    });
+    return HttpResponse.json({
+      data: { likeArtwork: { like } },
+    });
+  }),
+
+  graphql.mutation("UpdateAccountMutation", async ({ variables }) => {
+    const { accounts } = await getDb();
+    return HttpResponse.json({
+      data: {
+        updateAccount: {
+          account: {
+            ...accounts[0],
+            name: variables.input?.name ?? accounts[0].name,
+          },
+        },
+      },
+    });
+  }),
+
+  graphql.mutation("UpdateTagMutation", async ({ variables }) => {
+    const { tags } = await getDb();
+    const tag = tags.find((t) => t.id === variables.input?.id) ?? null;
+    return HttpResponse.json({
+      data: {
+        updateTag: {
+          tag: tag
+            ? {
+                ...tag,
+                canonicalName:
+                  variables.input?.canonicalName ?? tag.canonicalName,
+              }
+            : null,
+        },
+      },
+    });
+  }),
+];

--- a/front/src/mocks/handlers.ts
+++ b/front/src/mocks/handlers.ts
@@ -77,6 +77,31 @@ export const handlers = [
     });
   }),
 
+  graphql.query("TagsInputQuery", async () => {
+    const { tags } = await getDb();
+    return HttpResponse.json({
+      data: { allTags: toConnection(tags) },
+    });
+  }),
+
+  graphql.query("SlackChannelInputQuery", () => {
+    return HttpResponse.json({
+      data: {
+        allSlackChannels: [
+          { id: btoa("SlackChannel:1"), name: "general" },
+          { id: btoa("SlackChannel:2"), name: "illust" },
+        ],
+      },
+    });
+  }),
+
+  graphql.query("UploadArtworkModalQuery", async () => {
+    const { accounts } = await getDb();
+    return HttpResponse.json({
+      data: { viewer: { kmcid: accounts[0].kmcid } },
+    });
+  }),
+
   graphql.query("TaggedArtworksQuery", async ({ variables }) => {
     const { artworks, tags } = await getDb();
     const tag = tags.find((t) => t.name === variables.tag) ?? null;

--- a/front/src/vite-env.d.ts
+++ b/front/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_USE_MSW: string;
+  readonly VITE_BASENAME: string;
+  readonly VITE_REVISION: string;
+  readonly VITE_BUILT_AT: string;
+}

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## 概要

`VITE_USE_MSW=1` 環境変数を設定すると、MSW (Mock Service Worker) を使って `/api/graphql` へのリクエストをブラウザ内でモックします。バックエンドサーバーを起動しなくてもフロントエンドの動作確認ができるようになります。

## 動作確認方法

```bash
cd front
VITE_USE_MSW=1 npm run start
```

ブラウザのコンソールに `[MSW] Mocking enabled.` と表示されれば MSW が有効です。`VITE_USE_MSW` を指定しない場合は従来通り実際の `/api/graphql` に接続します。

## 変更内容

### 追加パッケージ
- `msw` v2 — Mock Service Worker 本体
- `@mizdra/graphql-codegen-typescript-fabbrica` — GraphQLスキーマからモックデータファクトリを生成するcodegen プラグイン
- `@graphql-codegen/typescript` — fabbrica の前提プラグイン
- `graphql` v15 → v16 にアップグレード（fabbrica の要件）

### 追加・変更ファイル

| ファイル | 内容 |
|---|---|
| `codegen.fabbrica.yml` | `schema.graphql` からファクトリ型を生成するcodegen設定 |
| `public/mockServiceWorker.js` | MSW サービスワーカースクリプト（`msw init` で生成） |
| `src/mocks/__generated__/types.ts` | GraphQLスキーマから生成した型定義 |
| `src/mocks/__generated__/fabbrica.ts` | 各型の `defineXxxFactory` ヘルパー（生成コード） |
| `src/mocks/factories.ts` | Account / Artwork / Illust / Tag / Comment / Like のファクトリ定義 |
| `src/mocks/db.ts` | ファクトリでビルドしたシードデータ（遅延初期化） |
| `src/mocks/handlers.ts` | 全クエリ・ミューテーションをインターセプトするMSWハンドラー |
| `src/mocks/browser.ts` | MSW ブラウザワーカーのセットアップ |
| `src/index.tsx` | `VITE_USE_MSW=1` のときのみ非同期で MSW を起動 |
| `src/vite-env.d.ts` | `VITE_USE_MSW` 環境変数の型定義を追加 |
| `tsconfig.json` | `moduleResolution` を `node` → `Bundler` に変更（fabbrica の要件） |

### モックデータ更新方法

`schema.graphql` が更新された際は以下を実行してファクトリを再生成します。

```bash
cd front
npm run codegen:mocks
```

## モックされる操作

**クエリ**
- `IndexQuery` — トップページ（作品一覧・アクティブユーザー）
- `ArtworkDetailQuery` — 作品詳細
- `UserDetailQuery` — ユーザーページ
- `RecentArtworksQuery` / `ArtworkListPaginationQuery` / `RecentArtworkListPaginationQuery` — 新着作品
- `TagsQuery` / `TaggedArtworksQuery` — タグ一覧・タグ別作品
- `RedirectToMyPageQuery` / `UploadArtworkQuery` / `RedirectFolderToArtworkQuery` — その他

**ミューテーション**
- `UploadArtworkMutation` / `UpdateArtworkMutation` / `DeleteArtworkMutation`
- `CreateCommentMutation` / `LikeArtworkMutation`
- `UpdateAccountMutation` / `UpdateTagMutation`

https://claude.ai/code/session_0153RijQha9Ya2y1E99kou7z

---
_Generated by [Claude Code](https://claude.ai/code/session_0153RijQha9Ya2y1E99kou7z)_