### PR TITLE
ci: GitHub ActionsのDependabot設定追加とアクションのコミットハッシュへのピン留め

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       DB_URL: 'sqlite:///:memory:'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # ref: api/Dockerfile
       - name: install deps
@@ -32,17 +32,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libjpeg-dev libwebp-dev imagemagick webp
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
           cache-dependency-path: ./api/poetry.lock
 
-      - uses: abatilo/actions-poetry@v3
+      - uses: abatilo/actions-poetry@fd0e6716a0de25ef6ade151b8b53190b0376acfd # v3
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: api/.venv
           key: ${{ runner.os }}-${{ env.PYTHON_VERSION }}-poetry-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -20,9 +20,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 20
           cache: "npm"
@@ -46,9 +46,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 20
           cache: "npm"
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload build artifacts
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build-artifacts
           path: front/dist


### PR DESCRIPTION
## 概要

- `.github/dependabot.yml` を追加し、GitHub Actionsの依存関係を週次で自動更新するDependabot設定を導入
- サプライチェーン攻撃対策として、全アクションのバージョン指定をコミットハッシュでピン留め

## 変更内容

### 新規追加: `.github/dependabot.yml`

`github-actions` エコシステムを対象に、週次でDependabotが更新チェックを行う設定を追加。

### ワークフローのアクションをコミットハッシュでピン留め

| アクション | タグ | コミットハッシュ |
|---|---|---|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-node` | v3 | `3235b876344d2a9aa001b8d1453c930bba69e610` |
| `actions/upload-artifact` | v4 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/setup-python` | v5 | `a26af69be951a213d495a4c3e4e4022e16d87065` |
| `actions/cache` | v3 | `6f8efc29b200d32929f49075959781ed54ec270c` |
| `abatilo/actions-poetry` | v3 | `fd0e6716a0de25ef6ade151b8b53190b0376acfd` |

コミットハッシュの後ろに `# v4` 等のバージョンコメントを付けているため、DependabotがPRを作成する際にハッシュとコメントの両方を自動更新します。