### PR TITLE
ページ遷移時にスピナーが表示されない問題を修正

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -29,12 +29,10 @@ export const App: React.VFC = () => {
   useEffect(() => {
     if (navigationType === "PUSH") {
       window.scrollTo(0, 0);
-      setDisplayLocation(currentLocation);
-    } else if (navigationType === "POP" || navigationType === "REPLACE") {
-      startTransition(() => {
-        setDisplayLocation(currentLocation);
-      });
     }
+    startTransition(() => {
+      setDisplayLocation(currentLocation);
+    });
   }, [currentLocation, navigationType, startTransition]);
 
   const navigate = useCallback<NavigateFn>(


### PR DESCRIPTION
## 概要

react-router v7 移行後、ページ遷移時にスピナーが表示されなくなっていた問題を修正します。

## 原因

`App.tsx` のナビゲーション処理で、PUSHナビゲーション時に `setDisplayLocation` を `startTransition` の外で呼び出していたため、`isPending` が `true` にならずスピナーが表示されませんでした。

旧コード（v5）では `navigate` コールバック内でナビゲーション種別を問わず常に `startTransition(() => setDisplayLocation(...))` を呼んでいました。

## 修正内容

すべてのナビゲーション種別（PUSH・POP・REPLACE）で `startTransition` 内で `displayLocation` を更新するよう統一しました。

---
_Generated by [Claude Code](https://claude.ai/code/session_011CyDfjdPCBqixtQDrKsNvS)_