### PR TITLE
Relay を v14 から v20 にアップグレード

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,8 +18,8 @@
         "@types/react-dom": "^18.2.7",
         "@types/react-helmet": "^6.1.6",
         "@types/react-infinite-scroller": "^1.2.3",
-        "@types/react-relay": "^13.0.0",
-        "@types/relay-runtime": "^13.0.0",
+        "@types/react-relay": "^18.2.1",
+        "@types/relay-runtime": "^20.1.1",
         "bootstrap": "^5.0.1",
         "bootstrap-icons": "^1.5.0",
         "clsx": "^1.1.1",
@@ -29,11 +29,11 @@
         "react-helmet": "^6.1.0",
         "react-infinite-scroller": "^1.2.6",
         "react-konva": "^18.2.10",
-        "react-relay": "^14.1.0",
+        "react-relay": "^20.1.1",
         "react-router": "^7",
         "react-string-replace": "^0.4.4",
         "react-use": "^17.4.0",
-        "relay-runtime": "^14.1.0"
+        "relay-runtime": "^20.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -46,7 +46,7 @@
         "@testing-library/user-event": "^12.1.10",
         "@trivago/prettier-plugin-sort-imports": "^6.0.1",
         "@vitejs/plugin-react": "^5.1.2",
-        "babel-plugin-relay": "^14.1.0",
+        "babel-plugin-relay": "^20.1.1",
         "eslint": "^9.17.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.2",
@@ -58,12 +58,12 @@
         "msw": "^2.14.6",
         "prettier": "^2.3.1",
         "react-test-renderer": "^18.2.0",
-        "relay-compiler": "^14.1.0",
+        "relay-compiler": "^20.1.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.51.0",
         "vite": "^7.3.2",
         "vite-plugin-node-polyfills": "^0.24.0",
-        "vite-plugin-relay": "^2.0.0",
+        "vite-plugin-relay": "^2.1.0",
         "vitest": "^4.0.16"
       }
     },
@@ -4556,7 +4556,9 @@
       }
     },
     "node_modules/@types/react-relay": {
-      "version": "13.0.0",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@types/react-relay/-/react-relay-18.2.1.tgz",
+      "integrity": "sha512-KgmFapsxAylhxcFfaAv5GZZJhTHnDvV8IDZVsUm5afpJUvgZC1Y68ssfOGsFfiFY/2EhxHM/YPfpdKbfmF3Ecg==",
       "license": "MIT",
       "dependencies": {
         "@types/react": "*",
@@ -4572,7 +4574,9 @@
       }
     },
     "node_modules/@types/relay-runtime": {
-      "version": "13.0.0",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@types/relay-runtime/-/relay-runtime-20.1.1.tgz",
+      "integrity": "sha512-loM2iJteknnJcsxrynmBVb7pIDkSkJUuCMnAa/oDFcrvaxkDvq8iy0J2UshMdDy14iJJocDblXeAu7c6Q1+Ucw==",
       "license": "MIT"
     },
     "node_modules/@types/set-cookie-parser": {
@@ -5314,6 +5318,8 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
     "node_modules/asn1.js": {
@@ -5453,10 +5459,11 @@
       }
     },
     "node_modules/babel-plugin-relay": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-relay/-/babel-plugin-relay-14.1.0.tgz",
-      "integrity": "sha512-1FTe0s07fGH/urhuVDWf9IPQd1UYcdvjCPPf5ixJJkK8+3cLAtseJ6dcyk1UnBSEDodRYwWLPhVOaGQIVvj3pw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-relay/-/babel-plugin-relay-20.1.1.tgz",
+      "integrity": "sha512-BWlqLPiHbxZTxlyng2rVgsZCwztHNje7H8FR4c+UKy3ErQJBG6BKLr9vUdeR7mAZCH2v0sOAxNhG6zR1FrWjAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "babel-plugin-macros": "^2.0.0",
         "cosmiconfig": "^5.0.5",
@@ -6325,6 +6332,35 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-inspect": {
       "version": "1.0.1",
@@ -7529,6 +7565,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
       "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+      "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "fbjs-css-vars": "^1.0.0",
@@ -7542,53 +7579,8 @@
     "node_modules/fbjs-css-vars": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
-    },
-    "node_modules/fbjs/node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
-    "node_modules/fbjs/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fbjs/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/fbjs/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/fbjs/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "license": "MIT"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -10711,6 +10703,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "license": "MIT",
       "dependencies": {
         "asap": "~2.0.3"
       }
@@ -10933,18 +10926,19 @@
       }
     },
     "node_modules/react-relay": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/react-relay/-/react-relay-14.1.0.tgz",
-      "integrity": "sha512-U4oHb5wn1LEi17x3AcZOy66MXs83tnYbsK7/YE1/3cQKCPrXhyVUQbEOC9L7jMX659jtS1NACae+7b03bryMCQ==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/react-relay/-/react-relay-20.1.1.tgz",
+      "integrity": "sha512-pwl7wHHXCOx32dOg4TVNkhVojgGVvOBMo9pcMGeM1BIFYvmwGauKTtBB+qr5buXHGooCL8TXjMVg+ZLizIsbeQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
+        "@babel/runtime": "^7.25.0",
         "fbjs": "^3.0.2",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
-        "relay-runtime": "14.1.0"
+        "relay-runtime": "20.1.1"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17 || ^18"
+        "react": "^16.9.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-router": {
@@ -11119,9 +11113,9 @@
       }
     },
     "node_modules/relay-compiler": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-14.1.0.tgz",
-      "integrity": "sha512-P8+CXm+Hq96z5NNwYl7hyGo5GgvMZDs9mXBRv7txUbJO4Ql9mXio3+D9EX3VfevRWTuE4ahM37i3Ssx1H604vA==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-20.1.1.tgz",
+      "integrity": "sha512-J/FFFLS/3vnbDkyQMw8l3Ev7dNHXMgC1RAs0fITz4Q63TFPOw142knKxY1Mm5ZZBABkAs9g2JghXaqM+phwTxw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -11129,11 +11123,12 @@
       }
     },
     "node_modules/relay-runtime": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-14.1.0.tgz",
-      "integrity": "sha512-t2DR2hZviHrdEQrOvFqwmvRWvZ0SjI/r4bS5f3qvMyXt4g1kw3RTb2RNVmbKGg6zEQhf7Na/brdqE4roApmclQ==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-20.1.1.tgz",
+      "integrity": "sha512-N98ZkkyuIHdXmHaPuljihM1QbFYXATF0gxA0CESFphszsQzXs9A/zZloVfzdOI/xg3B3CfM/5nozvIoeTDIcfw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
+        "@babel/runtime": "^7.25.0",
         "fbjs": "^3.0.2",
         "invariant": "^2.2.4"
       }
@@ -12340,6 +12335,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -12519,6 +12520,7 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
+      "license": "MIT",
       "bin": {
         "ua-parser-js": "script/cli.js"
       },
@@ -12926,6 +12928,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/front/package.json
+++ b/front/package.json
@@ -13,8 +13,8 @@
     "@types/react-dom": "^18.2.7",
     "@types/react-helmet": "^6.1.6",
     "@types/react-infinite-scroller": "^1.2.3",
-    "@types/react-relay": "^13.0.0",
-    "@types/relay-runtime": "^13.0.0",
+    "@types/react-relay": "^18.2.1",
+    "@types/relay-runtime": "^20.1.1",
     "bootstrap": "^5.0.1",
     "bootstrap-icons": "^1.5.0",
     "clsx": "^1.1.1",
@@ -24,11 +24,11 @@
     "react-helmet": "^6.1.0",
     "react-infinite-scroller": "^1.2.6",
     "react-konva": "^18.2.10",
-    "react-relay": "^14.1.0",
+    "react-relay": "^20.1.1",
     "react-router": "^7",
     "react-string-replace": "^0.4.4",
     "react-use": "^17.4.0",
-    "relay-runtime": "^14.1.0"
+    "relay-runtime": "^20.1.1"
   },
   "scripts": {
     "start": "env VITE_REVISION=`git rev-parse HEAD` VITE_BUILT_AT=`date +%s` vite",
@@ -50,8 +50,7 @@
     "schema": "./schema.graphql",
     "src": "./src",
     "language": "typescript",
-    "eagerEsModules": true,
-    "customScalars": {
+    "customScalarTypes": {
       "DateTime": "string",
       "Upload": "null"
     }
@@ -79,7 +78,7 @@
     "@testing-library/user-event": "^12.1.10",
     "@trivago/prettier-plugin-sort-imports": "^6.0.1",
     "@vitejs/plugin-react": "^5.1.2",
-    "babel-plugin-relay": "^14.1.0",
+    "babel-plugin-relay": "^20.1.1",
     "eslint": "^9.17.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.2",
@@ -91,16 +90,13 @@
     "msw": "^2.14.6",
     "prettier": "^2.3.1",
     "react-test-renderer": "^18.2.0",
-    "relay-compiler": "^14.1.0",
+    "relay-compiler": "^20.1.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.51.0",
     "vite": "^7.3.2",
     "vite-plugin-node-polyfills": "^0.24.0",
-    "vite-plugin-relay": "^2.0.0",
+    "vite-plugin-relay": "^2.1.0",
     "vitest": "^4.0.16"
-  },
-  "resolutions": {
-    "@types/relay-runtime": "~13.0.0"
   },
   "msw": {
     "workerDirectory": [

--- a/front/src/components/ArtworkDetail/ArtworkLikeList.tsx
+++ b/front/src/components/ArtworkDetail/ArtworkLikeList.tsx
@@ -88,7 +88,7 @@ interface LikeIconProps {
     readonly account: {
       readonly id: string;
       readonly kmcid: string;
-    } | null;
+    } | null | undefined;
   };
 }
 

--- a/front/src/components/ArtworkDetail/__generated__/ArtworkComment_comments.graphql.ts
+++ b/front/src/components/ArtworkDetail/__generated__/ArtworkComment_comments.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<27f7955b08e9726fa4bf9369b9752d6d>>
+ * @generated SignedSource<<2948a182d1e1786b915b15143b53c3a4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkComment_comments$data = {
   readonly artworkId: string;
@@ -18,12 +18,12 @@ export type ArtworkComment_comments$data = {
       readonly node: {
         readonly account: {
           readonly kmcid: string;
-        } | null;
+        } | null | undefined;
         readonly createdAt: string;
         readonly text: string;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
   readonly " $fragmentType": "ArtworkComment_comments";
 };
 export type ArtworkComment_comments$key = {

--- a/front/src/components/ArtworkDetail/__generated__/ArtworkLikeList_likes.graphql.ts
+++ b/front/src/components/ArtworkDetail/__generated__/ArtworkLikeList_likes.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aad47e76d4f45e491aa021b3446eb231>>
+ * @generated SignedSource<<f920c5b52ca20bb310826cec405ae0c2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkLikeList_likes$data = {
   readonly artworkId: string;
@@ -19,10 +19,10 @@ export type ArtworkLikeList_likes$data = {
         readonly account: {
           readonly id: string;
           readonly kmcid: string;
-        } | null;
-      } | null;
-    } | null>;
-  } | null;
+        } | null | undefined;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
   readonly " $fragmentType": "ArtworkLikeList_likes";
 };
 export type ArtworkLikeList_likes$key = {

--- a/front/src/components/ArtworkDetail/__generated__/IllustCarousel_illusts.graphql.ts
+++ b/front/src/components/ArtworkDetail/__generated__/IllustCarousel_illusts.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<86ae95eae4319ac4aba0560a39e9a509>>
+ * @generated SignedSource<<9766cc49e9e03751b3edc01a51e0f54a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type IllustCarousel_illusts$data = {
   readonly illusts: {
@@ -18,9 +18,9 @@ export type IllustCarousel_illusts$data = {
         readonly imageUrl: string;
         readonly thumbnailUrl: string;
         readonly webpUrl: string;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
   readonly " $fragmentType": "IllustCarousel_illusts";
 };
 export type IllustCarousel_illusts$key = {

--- a/front/src/components/ArtworkDetail/__generated__/UpdateArtworkForm_artwork.graphql.ts
+++ b/front/src/components/ArtworkDetail/__generated__/UpdateArtworkForm_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a4ffd0e35b19574dbebcad9bf5b3136b>>
+ * @generated SignedSource<<56983d472c1237f9629fe201bb80477d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 export type ArtworkRatingEnum = "r_18" | "r_18g" | "safe" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type UpdateArtworkForm_artwork$data = {
@@ -19,9 +19,9 @@ export type UpdateArtworkForm_artwork$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly name: string;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
   readonly title: string;
   readonly " $fragmentType": "UpdateArtworkForm_artwork";
 };

--- a/front/src/components/ArtworkInfoForm/__generated__/SlackChannelInputQuery.graphql.ts
+++ b/front/src/components/ArtworkInfoForm/__generated__/SlackChannelInputQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<afb07f1ef8db7b386cad3a1928c28e98>>
+ * @generated SignedSource<<3eb7bf71f8aef34a13f14a13518db9cb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,13 +8,13 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
-export type SlackChannelInputQuery$variables = {};
+import { ConcreteRequest } from 'relay-runtime';
+export type SlackChannelInputQuery$variables = Record<PropertyKey, never>;
 export type SlackChannelInputQuery$data = {
   readonly allSlackChannels: ReadonlyArray<{
     readonly id: string;
     readonly name: string;
-  } | null>;
+  } | null | undefined>;
 };
 export type SlackChannelInputQuery = {
   response: SlackChannelInputQuery$data;

--- a/front/src/components/ArtworkInfoForm/__generated__/TagsInputQuery.graphql.ts
+++ b/front/src/components/ArtworkInfoForm/__generated__/TagsInputQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fe5752e2f0b60718e65f4bba3dad6583>>
+ * @generated SignedSource<<0f048413cd1d64265161185bc707fa4d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,17 +8,17 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
-export type TagsInputQuery$variables = {};
+import { ConcreteRequest } from 'relay-runtime';
+export type TagsInputQuery$variables = Record<PropertyKey, never>;
 export type TagsInputQuery$data = {
   readonly allTags: {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly artworksCount: number;
         readonly name: string;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
 };
 export type TagsInputQuery = {
   response: TagsInputQuery$data;

--- a/front/src/components/TaggedArtworks/__generated__/UpdateTagModal_tag.graphql.ts
+++ b/front/src/components/TaggedArtworks/__generated__/UpdateTagModal_tag.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4a10fd506c4de50120d5d0c3f6f13ea4>>
+ * @generated SignedSource<<7290f305ca8e023e0cff4d6946d1d809>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type UpdateTagModal_tag$data = {
   readonly canonicalName: string;

--- a/front/src/components/TegakiDU/UploadArtworkModal.tsx
+++ b/front/src/components/TegakiDU/UploadArtworkModal.tsx
@@ -90,7 +90,7 @@ export const UploadArtworkModal: React.VFC<Props> = ({ blob }) => {
     { fetchPolicy: "store-or-network" }
   );
   useEffect(() => {
-    setTwitterUserName(viewer === null ? "" : viewer.kmcid);
+    setTwitterUserName(!viewer ? "" : viewer.kmcid);
   }, []);
 
   const { ageRestriction } = useArtworkInformation();

--- a/front/src/components/TegakiDU/__generated__/UploadArtworkModalQuery.graphql.ts
+++ b/front/src/components/TegakiDU/__generated__/UploadArtworkModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<999a19c2d83d691ca2b106ac227aa629>>
+ * @generated SignedSource<<e93af92288263f0e9de0999557226578>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,12 +8,12 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
-export type UploadArtworkModalQuery$variables = {};
+import { ConcreteRequest } from 'relay-runtime';
+export type UploadArtworkModalQuery$variables = Record<PropertyKey, never>;
 export type UploadArtworkModalQuery$data = {
   readonly viewer: {
     readonly kmcid: string;
-  } | null;
+  } | null | undefined;
 };
 export type UploadArtworkModalQuery = {
   response: UploadArtworkModalQuery$data;

--- a/front/src/components/UserDetail/__generated__/UpdateInfoForm_account.graphql.ts
+++ b/front/src/components/UserDetail/__generated__/UpdateInfoForm_account.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9c85f9f8220d7be9f52c0d5325bba67e>>
+ * @generated SignedSource<<9db36195b758cd66aaeaa439a886864d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type UpdateInfoForm_account$data = {
   readonly kmcid: string;

--- a/front/src/components/__generated__/ArtworkListItem_artwork.graphql.ts
+++ b/front/src/components/__generated__/ArtworkListItem_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2a4cf3997d5f6684b0947122ea01080b>>
+ * @generated SignedSource<<938833838899d5398e2d9c76539d0875>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,19 +8,19 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkListItem_artwork$data = {
   readonly account: {
     readonly name: string;
-  } | null;
+  } | null | undefined;
   readonly caption: string;
   readonly id: string;
   readonly nsfw: boolean;
   readonly title: string;
   readonly topIllust: {
     readonly thumbnailUrl: string;
-  } | null;
+  } | null | undefined;
   readonly " $fragmentType": "ArtworkListItem_artwork";
 };
 export type ArtworkListItem_artwork$key = {

--- a/front/src/mutation/__generated__/CreateCommentMutation.graphql.ts
+++ b/front/src/mutation/__generated__/CreateCommentMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a0eb02d62d9a35411ad233dd132f9a93>>
+ * @generated SignedSource<<6a1d5e135173775faf4d9bbffd327845>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,10 +8,10 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 export type CreateCommentInput = {
   artworkId: string;
-  clientMutationId?: string | null;
+  clientMutationId?: string | null | undefined;
   text: string;
 };
 export type CreateCommentMutation$variables = {
@@ -23,11 +23,11 @@ export type CreateCommentMutation$data = {
     readonly comment: {
       readonly account: {
         readonly kmcid: string;
-      } | null;
+      } | null | undefined;
       readonly createdAt: string;
       readonly text: string;
-    } | null;
-  } | null;
+    } | null | undefined;
+  } | null | undefined;
 };
 export type CreateCommentMutation = {
   response: CreateCommentMutation$data;

--- a/front/src/mutation/__generated__/DeleteArtworkMutation.graphql.ts
+++ b/front/src/mutation/__generated__/DeleteArtworkMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<201446e68467582be723ba9d27a3fae8>>
+ * @generated SignedSource<<a6aac3c029aa12eea18ac8307fa58a50>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,9 +8,9 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 export type DeleteArtworkInput = {
-  clientMutationId?: string | null;
+  clientMutationId?: string | null | undefined;
   id: string;
 };
 export type DeleteArtworkMutation$variables = {
@@ -19,8 +19,8 @@ export type DeleteArtworkMutation$variables = {
 };
 export type DeleteArtworkMutation$data = {
   readonly deleteArtwork: {
-    readonly deletedArtworkId: string | null;
-  } | null;
+    readonly deletedArtworkId: string | null | undefined;
+  } | null | undefined;
 };
 export type DeleteArtworkMutation = {
   response: DeleteArtworkMutation$data;

--- a/front/src/mutation/__generated__/LikeArtworkMutation.graphql.ts
+++ b/front/src/mutation/__generated__/LikeArtworkMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<16efff4e1838212ac0b7489d5fcfcaaa>>
+ * @generated SignedSource<<220b314619078d37fe71d2f81233911a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,10 +8,10 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 export type LikeArtworkInput = {
   artworkId: string;
-  clientMutationId?: string | null;
+  clientMutationId?: string | null | undefined;
 };
 export type LikeArtworkMutation$variables = {
   connections: ReadonlyArray<string>;
@@ -23,10 +23,10 @@ export type LikeArtworkMutation$data = {
       readonly account: {
         readonly id: string;
         readonly kmcid: string;
-      } | null;
+      } | null | undefined;
       readonly id: string;
-    } | null;
-  } | null;
+    } | null | undefined;
+  } | null | undefined;
 };
 export type LikeArtworkMutation = {
   response: LikeArtworkMutation$data;

--- a/front/src/mutation/__generated__/UpdateAccountMutation.graphql.ts
+++ b/front/src/mutation/__generated__/UpdateAccountMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c62f36ec50a9aa4a68f884c0bc94ee03>>
+ * @generated SignedSource<<ea261a7f2715742a57ee7b3e9652590a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,9 +8,9 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 export type UpdateAccountInput = {
-  clientMutationId?: string | null;
+  clientMutationId?: string | null | undefined;
   name: string;
 };
 export type UpdateAccountMutation$variables = {
@@ -22,8 +22,8 @@ export type UpdateAccountMutation$data = {
       readonly id: string;
       readonly kmcid: string;
       readonly name: string;
-    } | null;
-  } | null;
+    } | null | undefined;
+  } | null | undefined;
 };
 export type UpdateAccountMutation = {
   response: UpdateAccountMutation$data;

--- a/front/src/mutation/__generated__/UpdateArtworkMutation.graphql.ts
+++ b/front/src/mutation/__generated__/UpdateArtworkMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<679f3da4518ea75e4ae527f4f20006f6>>
+ * @generated SignedSource<<f26aca39f5ffd1f017b0e72169a60dbd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,13 +8,13 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 export type ArtworkRatingEnum = "r_18" | "r_18g" | "safe" | "%future added value";
 export type UpdateArtworkInput = {
   caption: string;
-  clientMutationId?: string | null;
+  clientMutationId?: string | null | undefined;
   id: string;
-  rating?: ArtworkRatingEnum | null;
+  rating?: ArtworkRatingEnum | null | undefined;
   tags: ReadonlyArray<string>;
   title: string;
 };
@@ -31,12 +31,12 @@ export type UpdateArtworkMutation$data = {
         readonly edges: ReadonlyArray<{
           readonly node: {
             readonly name: string;
-          } | null;
-        } | null>;
-      } | null;
+          } | null | undefined;
+        } | null | undefined>;
+      } | null | undefined;
       readonly title: string;
-    } | null;
-  } | null;
+    } | null | undefined;
+  } | null | undefined;
 };
 export type UpdateArtworkMutation = {
   response: UpdateArtworkMutation$data;

--- a/front/src/mutation/__generated__/UpdateTagMutation.graphql.ts
+++ b/front/src/mutation/__generated__/UpdateTagMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1b476c1a7c6177aa9cac92226a0ef985>>
+ * @generated SignedSource<<c1b4b4914270302176d8637a4b8dc147>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,9 +8,9 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 export type UpdateTagInput = {
-  clientMutationId?: string | null;
+  clientMutationId?: string | null | undefined;
   id: string;
   name: string;
 };
@@ -22,8 +22,8 @@ export type UpdateTagMutation$data = {
     readonly tag: {
       readonly id: string;
       readonly name: string;
-    } | null;
-  } | null;
+    } | null | undefined;
+  } | null | undefined;
 };
 export type UpdateTagMutation = {
   response: UpdateTagMutation$data;

--- a/front/src/mutation/__generated__/UploadArtworkMutation.graphql.ts
+++ b/front/src/mutation/__generated__/UploadArtworkMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f04580b64291fa0cbe4d6820ca35526e>>
+ * @generated SignedSource<<b27fea7d5684ebf9862106f2d6f81712>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,23 +8,23 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Mutation } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 export type ArtworkRatingEnum = "r_18" | "r_18g" | "safe" | "%future added value";
 export type SlackShareOptionEnum = "NONE" | "SHARE_TO_SLACK" | "SHARE_TO_SLACK_WITH_IMAGE" | "%future added value";
 export type UploadArtworkInput = {
   caption: string;
-  channelId?: string | null;
-  clientMutationId?: string | null;
+  channelId?: string | null | undefined;
+  clientMutationId?: string | null | undefined;
   files: ReadonlyArray<null>;
   rating: ArtworkRatingEnum;
-  shareOption?: SlackShareOptionEnum | null;
+  shareOption?: SlackShareOptionEnum | null | undefined;
   tags: ReadonlyArray<string>;
   title: string;
-  twitterShareOption?: TwitterShareOption | null;
+  twitterShareOption?: TwitterShareOption | null | undefined;
 };
 export type TwitterShareOption = {
   share: boolean;
-  username?: string | null;
+  username?: string | null | undefined;
 };
 export type UploadArtworkMutation$variables = {
   connections: ReadonlyArray<string>;
@@ -34,8 +34,8 @@ export type UploadArtworkMutation$data = {
   readonly uploadArtwork: {
     readonly artwork: {
       readonly id: string;
-    } | null;
-  } | null;
+    } | null | undefined;
+  } | null | undefined;
 };
 export type UploadArtworkMutation = {
   response: UploadArtworkMutation$data;

--- a/front/src/pages/UploadArtwork.tsx
+++ b/front/src/pages/UploadArtwork.tsx
@@ -119,7 +119,7 @@ const UploadArtworkForm = () => {
     { fetchPolicy: "store-or-network" }
   );
   useEffect(() => {
-    setTwitterUserName(viewer === null ? "" : viewer.kmcid);
+    setTwitterUserName(!viewer ? "" : viewer.kmcid);
   }, []);
 
   const { ageRestriction } = useArtworkInformation();

--- a/front/src/pages/__generated__/ArtworkDetailQuery.graphql.ts
+++ b/front/src/pages/__generated__/ArtworkDetailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<04dc5eb2ca1f81de2ec519560d0d5f70>>
+ * @generated SignedSource<<07ff394ee0675c28e313da77277a04ea>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkRatingEnum = "r_18" | "r_18g" | "safe" | "%future added value";
 export type ArtworkDetailQuery$variables = {
@@ -21,7 +21,7 @@ export type ArtworkDetailQuery$data = {
       readonly id: string;
       readonly kmcid: string;
       readonly name: string;
-    } | null;
+    } | null | undefined;
     readonly caption: string;
     readonly createdAt: string;
     readonly editable: boolean;
@@ -32,32 +32,32 @@ export type ArtworkDetailQuery$data = {
       readonly title: string;
       readonly topIllust: {
         readonly thumbnailUrl: string;
-      } | null;
-    } | null;
+      } | null | undefined;
+    } | null | undefined;
     readonly previousArtwork: {
       readonly id: string;
       readonly nsfw: boolean;
       readonly title: string;
       readonly topIllust: {
         readonly thumbnailUrl: string;
-      } | null;
-    } | null;
+      } | null | undefined;
+    } | null | undefined;
     readonly rating: ArtworkRatingEnum;
     readonly tags: {
       readonly edges: ReadonlyArray<{
         readonly node: {
           readonly id: string;
           readonly name: string;
-        } | null;
-      } | null>;
-    } | null;
+        } | null | undefined;
+      } | null | undefined>;
+    } | null | undefined;
     readonly title: string;
     readonly " $fragmentSpreads": FragmentRefs<"ArtworkComment_comments" | "ArtworkLikeList_likes" | "IllustCarousel_illusts" | "UpdateArtworkForm_artwork">;
   } | {
     // This will never be '%other', but we need some
     // value in case none of the concrete values match.
     readonly __typename: "%other";
-  } | null;
+  } | null | undefined;
 };
 export type ArtworkDetailQuery = {
   response: ArtworkDetailQuery$data;

--- a/front/src/pages/__generated__/ArtworkListPaginationQuery.graphql.ts
+++ b/front/src/pages/__generated__/ArtworkListPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c9eae92f2f2708f1f7ab5ed09cd4d81f>>
+ * @generated SignedSource<<245805bb95becf4796cafdae89eaa77b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,17 +8,17 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkListPaginationQuery$variables = {
-  count?: number | null;
-  cursor?: string | null;
+  count?: number | null | undefined;
+  cursor?: string | null | undefined;
   id: string;
 };
 export type ArtworkListPaginationQuery$data = {
   readonly node: {
     readonly " $fragmentSpreads": FragmentRefs<"UserDetail_artworks">;
-  } | null;
+  } | null | undefined;
 };
 export type ArtworkListPaginationQuery = {
   response: ArtworkListPaginationQuery$data;

--- a/front/src/pages/__generated__/IndexQuery.graphql.ts
+++ b/front/src/pages/__generated__/IndexQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<adfae5449625a532ce3be885f807950a>>
+ * @generated SignedSource<<8f478af7e74283de2eee7cab97022cc4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,9 +8,9 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type IndexQuery$variables = {};
+export type IndexQuery$variables = Record<PropertyKey, never>;
 export type IndexQuery$data = {
   readonly activeAccounts: {
     readonly edges: ReadonlyArray<{
@@ -19,17 +19,17 @@ export type IndexQuery$data = {
         readonly id: string;
         readonly kmcid: string;
         readonly name: string;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
   readonly safeArtworks: {
     readonly __id: string;
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly " $fragmentSpreads": FragmentRefs<"ArtworkListItem_artwork">;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
 };
 export type IndexQuery = {
   response: IndexQuery$data;

--- a/front/src/pages/__generated__/RecentArtworkListPaginationQuery.graphql.ts
+++ b/front/src/pages/__generated__/RecentArtworkListPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2d77ef0290dac72ad5f99dd5ddcbcd94>>
+ * @generated SignedSource<<ec916e9d8646bdcfdcfb37f34fd6b281>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,13 +8,13 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkRatingEnum = "r_18" | "r_18g" | "safe" | "%future added value";
 export type RecentArtworkListPaginationQuery$variables = {
-  count?: number | null;
-  cursor?: string | null;
-  rating?: ReadonlyArray<ArtworkRatingEnum> | null;
+  count?: number | null | undefined;
+  cursor?: string | null | undefined;
+  rating?: ReadonlyArray<ArtworkRatingEnum> | null | undefined;
 };
 export type RecentArtworkListPaginationQuery$data = {
   readonly " $fragmentSpreads": FragmentRefs<"RecentArtworks_artworks">;

--- a/front/src/pages/__generated__/RecentArtworksQuery.graphql.ts
+++ b/front/src/pages/__generated__/RecentArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d1524e975c4c7ff3e05793a4845bd8e3>>
+ * @generated SignedSource<<9995c6c76316ab9d836d1570d2d4c362>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkRatingEnum = "r_18" | "r_18g" | "safe" | "%future added value";
 export type RecentArtworksQuery$variables = {

--- a/front/src/pages/__generated__/RecentArtworks_artworks.graphql.ts
+++ b/front/src/pages/__generated__/RecentArtworks_artworks.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d75def9a8e96ee2c8a80a1e9f18c75aa>>
+ * @generated SignedSource<<9a87de1b648e1a55cd1b850f1648034c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,16 +8,16 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type RecentArtworks_artworks$data = {
   readonly artworks: {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly " $fragmentSpreads": FragmentRefs<"ArtworkListItem_artwork">;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
   readonly " $fragmentType": "RecentArtworks_artworks";
 };
 export type RecentArtworks_artworks$key = {

--- a/front/src/pages/__generated__/RedirectFolderToArtworkQuery.graphql.ts
+++ b/front/src/pages/__generated__/RedirectFolderToArtworkQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b6bf47a5b4cc0d7c0d1b5b18a0cc2399>>
+ * @generated SignedSource<<b513f52d12fb9f0b354f1d45c8772053>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,14 +8,14 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 export type RedirectFolderToArtworkQuery$variables = {
   folderId: number;
 };
 export type RedirectFolderToArtworkQuery$data = {
   readonly artworkByFolderId: {
     readonly id: string;
-  } | null;
+  } | null | undefined;
 };
 export type RedirectFolderToArtworkQuery = {
   response: RedirectFolderToArtworkQuery$data;

--- a/front/src/pages/__generated__/RedirectToMyPageQuery.graphql.ts
+++ b/front/src/pages/__generated__/RedirectToMyPageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8684de938606c0b95e580c50d480ed89>>
+ * @generated SignedSource<<bfe74283788c171c6273c459b3b73928>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,12 +8,12 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
-export type RedirectToMyPageQuery$variables = {};
+import { ConcreteRequest } from 'relay-runtime';
+export type RedirectToMyPageQuery$variables = Record<PropertyKey, never>;
 export type RedirectToMyPageQuery$data = {
   readonly viewer: {
     readonly kmcid: string;
-  } | null;
+  } | null | undefined;
 };
 export type RedirectToMyPageQuery = {
   response: RedirectToMyPageQuery$data;

--- a/front/src/pages/__generated__/TaggedArtworksQuery.graphql.ts
+++ b/front/src/pages/__generated__/TaggedArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e295004222c776c6e04f8738b39fbef8>>
+ * @generated SignedSource<<a8b7392a24cc62a1cb3e3717224350a3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type TaggedArtworksQuery$variables = {
   tag: string;
@@ -17,14 +17,14 @@ export type TaggedArtworksQuery$data = {
   readonly tagByName: {
     readonly editFreezed: boolean;
     readonly " $fragmentSpreads": FragmentRefs<"UpdateTagModal_tag">;
-  } | null;
+  } | null | undefined;
   readonly taggedArtworks: {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly " $fragmentSpreads": FragmentRefs<"ArtworkListItem_artwork">;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
 };
 export type TaggedArtworksQuery = {
   response: TaggedArtworksQuery$data;

--- a/front/src/pages/__generated__/TagsQuery.graphql.ts
+++ b/front/src/pages/__generated__/TagsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b01ae547cf051b30386fdd7194fd3c2a>>
+ * @generated SignedSource<<f1991a25285696ccafeec682e466d6c4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,17 +8,17 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
-export type TagsQuery$variables = {};
+import { ConcreteRequest } from 'relay-runtime';
+export type TagsQuery$variables = Record<PropertyKey, never>;
 export type TagsQuery$data = {
   readonly allTags: {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly artworksCount: number;
         readonly name: string;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
 };
 export type TagsQuery = {
   response: TagsQuery$data;

--- a/front/src/pages/__generated__/UploadArtworkQuery.graphql.ts
+++ b/front/src/pages/__generated__/UploadArtworkQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f1d9929d3925209b905d822d7890912a>>
+ * @generated SignedSource<<dcf912edf2dcce3e9418d44517e8abe9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,12 +8,12 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
-export type UploadArtworkQuery$variables = {};
+import { ConcreteRequest } from 'relay-runtime';
+export type UploadArtworkQuery$variables = Record<PropertyKey, never>;
 export type UploadArtworkQuery$data = {
   readonly viewer: {
     readonly kmcid: string;
-  } | null;
+  } | null | undefined;
 };
 export type UploadArtworkQuery = {
   response: UploadArtworkQuery$data;

--- a/front/src/pages/__generated__/UserDetailQuery.graphql.ts
+++ b/front/src/pages/__generated__/UserDetailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<98cb2ad769c12e1c1e9dcffc2165fdf6>>
+ * @generated SignedSource<<dab46b1d1e047bddced6d736de528de6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ConcreteRequest, Query } from 'relay-runtime';
+import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type UserDetailQuery$variables = {
   kmcid: string;
@@ -20,7 +20,7 @@ export type UserDetailQuery$data = {
     readonly kmcid: string;
     readonly name: string;
     readonly " $fragmentSpreads": FragmentRefs<"UpdateInfoForm_account" | "UserDetail_artworks">;
-  } | null;
+  } | null | undefined;
 };
 export type UserDetailQuery = {
   response: UserDetailQuery$data;

--- a/front/src/pages/__generated__/UserDetail_artworks.graphql.ts
+++ b/front/src/pages/__generated__/UserDetail_artworks.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f58670435d829f97fee32f5ef9f66bf3>>
+ * @generated SignedSource<<0b8ee785f502c51f17a581707767d47c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,16 +8,16 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type UserDetail_artworks$data = {
   readonly artworks: {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly " $fragmentSpreads": FragmentRefs<"ArtworkListItem_artwork">;
-      } | null;
-    } | null>;
-  } | null;
+      } | null | undefined;
+    } | null | undefined>;
+  } | null | undefined;
   readonly id: string;
   readonly " $fragmentType": "UserDetail_artworks";
 };
@@ -68,7 +68,10 @@ return {
         "node"
       ],
       "operation": ArtworkListPaginationQuery_graphql,
-      "identifierField": "id"
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
     }
   },
   "name": "UserDetail_artworks",


### PR DESCRIPTION
## 概要

RelayのGraphQLクライアントライブラリをv14.1.0からv20.1.1（最新版）にアップグレードします。

## 変更内容

### パッケージのアップグレード
| パッケージ | 変更前 | 変更後 |
|-----------|--------|--------|
| `react-relay` | v14.1.0 | v20.1.1 |
| `relay-runtime` | v14.1.0 | v20.1.1 |
| `relay-compiler` | v14.1.0 | v20.1.1 |
| `babel-plugin-relay` | v14.1.0 | v20.1.1 |
| `vite-plugin-relay` | v2.0.0 | v2.1.0 |
| `@types/react-relay` | v13.0.0 | v18.2.1 |
| `@types/relay-runtime` | v13.0.0 | v20.1.1 |

### Relay コンパイラ設定の変更
- `customScalars` → `customScalarTypes` にリネーム（v20のフォーマットに対応）
- 廃止済みオプション `eagerEsModules: true` を削除（v16以降でESモジュールがデフォルト）
- `@types/relay-runtime` の `resolutions` エントリを削除

### ソースコードの修正
- `UploadArtworkModal.tsx`, `UploadArtwork.tsx`: `viewer === null` を `!viewer` に変更（v20の生成型が `null | undefined` になったため）
- `ArtworkLikeList.tsx`: `LikeIconProps` の `account` 型に `undefined` を追加

### 生成ファイルの再生成
relay-compiler v20 で全 `__generated__/*.graphql.ts` を再生成。nullable型が `| null` から `| null | undefined` に変更されています。

https://claude.ai/code/session_01Xijw85ZBs7jgqa8MC9Dc8i