### PR TITLE
Upgrade actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload build artifacts
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-artifacts
           path: front/dist


### PR DESCRIPTION
## Summary
Updated the `actions/upload-artifact` GitHub Action dependency from v4 to v7.0.1 in the front-end CI workflow.

## Changes
- Upgraded `actions/upload-artifact` action from v4 (commit `ea165f8d65b6e75b540449e92b4886f43607fa02`) to v7.0.1 (commit `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`)
- This update applies to the artifact upload step in the main branch build pipeline

## Details
This is a major version upgrade that brings improvements and bug fixes from the newer version of the upload-artifact action. The action continues to upload build artifacts from the `front/dist` directory when changes are pushed to the main branch.

https://claude.ai/code/session_01BGi6yAVUUCQiN24brBed5C