### PR TITLE
fix: Dockerfile の Poetry バージョンを lockfile に合わせて更新

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -56,3 +56,11 @@ jobs:
         working-directory: ./api
         env:
           DB_URL: 'sqlite:///:memory:'
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build Docker image
+        run: docker build ./api

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,7 +21,7 @@ COPY ./poetry.toml ./
 COPY ./pyproject.toml ./poetry.lock ./
 RUN poetry install --no-root
 
-COPY ./alembic.ini ./pytest.ini ./.env.test ./
+COPY ./pytest.ini ./.env.test ./
 COPY ./script ./script
 COPY ./src ./src
 RUN poetry install

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,13 +13,13 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=yes
 ENV POETRY_HOME="/opt/poetry"
 ENV POETRY_NO_INTERACTION=1
 ENV PATH="$POETRY_HOME/bin:$PATH"
-ENV POETRY_VERSION=1.8.3
+ENV POETRY_VERSION=2.2.1
 RUN curl -sSL https://install.python-poetry.org | python3 -
 RUN chmod 755 $POETRY_HOME/bin/poetry
 
 COPY ./poetry.toml ./
 COPY ./pyproject.toml ./poetry.lock ./
-RUN poetry install
+RUN poetry install --no-root
 
 COPY ./alembic.ini ./pytest.ini ./.env.test ./
 COPY ./script ./script


### PR DESCRIPTION
## 概要

`api/Dockerfile` と現行の技術スタックのギャップを解消し、`docker build` が通るようにします。

## 問題

1. **Poetry バージョンの不整合**: `poetry.lock` は **Poetry 2.2.1** で生成されているが、Dockerfile では `POETRY_VERSION=1.8.3`（1.x系）を指定していた。Poetry 1.x は Poetry 2.x 形式のロックファイルを読めないためビルドが失敗する。

2. **存在しないファイルの COPY**: Dockerfile が `alembic.ini` を COPY しようとしていたが、このファイルはリポジトリに存在しない（alembic は obsolete なスクリプト内でのみ参照されている過去の遺物）。

## 変更内容

- `POETRY_VERSION` を `1.8.3` → `2.2.1` に更新（`poetry.lock` の生成バージョンに合わせた）
- ソースコードコピー前の `poetry install` に `--no-root` を追加（Poetry 2.x ではソースが存在しない段階でルートパッケージのインストールを試みるため）
- Dockerfile の COPY から存在しない `alembic.ini` を削除
- CI に `docker-build` ジョブを追加し、今後 Dockerfile のビルドが壊れないことを継続的に検証できるようにした