### PR TITLE
React.VFC を React.FC に移行する

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -19,7 +19,7 @@ import { Header } from "./components/Header";
 import { LoadingOverlay } from "./components/LoadingOverlay";
 import { NavigationContext, NavigateFn } from "./contexts/NavigationContext";
 
-export const App: React.VFC = () => {
+export const App: React.FC = () => {
   const currentLocation = useLocation();
   const navigationType = useNavigationType();
   const routerNavigate = useRouterNavigate();

--- a/front/src/components/ArtworkDetail/ArtworkComment.tsx
+++ b/front/src/components/ArtworkDetail/ArtworkComment.tsx
@@ -9,7 +9,7 @@ interface Props {
   artwork: ArtworkComment_comments$key;
 }
 
-export const ArtworkComment: React.VFC<Props> = ({ artwork }) => {
+export const ArtworkComment: React.FC<Props> = ({ artwork }) => {
   const { artworkId, comments } = useFragment<ArtworkComment_comments$key>(
     graphql`
       fragment ArtworkComment_comments on Artwork {
@@ -68,7 +68,7 @@ export const ArtworkComment: React.VFC<Props> = ({ artwork }) => {
   );
 };
 
-const CommentForm: React.VFC<{ artworkId: string; connectionId: string }> = ({
+const CommentForm: React.FC<{ artworkId: string; connectionId: string }> = ({
   artworkId,
   connectionId,
 }) => {

--- a/front/src/components/ArtworkDetail/ArtworkLikeList.tsx
+++ b/front/src/components/ArtworkDetail/ArtworkLikeList.tsx
@@ -11,7 +11,7 @@ interface Props {
   artwork: ArtworkLikeList_likes$key;
 }
 
-export const LikeList: React.VFC<Props> = ({ artwork }) => {
+export const LikeList: React.FC<Props> = ({ artwork }) => {
   const { artworkId, likes } = useFragment<ArtworkLikeList_likes$key>(
     graphql`
       fragment ArtworkLikeList_likes on Artwork {
@@ -95,7 +95,7 @@ interface LikeIconProps {
   };
 }
 
-const LikeIcon: React.VFC<LikeIconProps> = ({ like }) => {
+const LikeIcon: React.FC<LikeIconProps> = ({ like }) => {
   const ref = useTooltip<HTMLAnchorElement>();
 
   if (!like.account) {

--- a/front/src/components/ArtworkDetail/DeleteArtworkButton.tsx
+++ b/front/src/components/ArtworkDetail/DeleteArtworkButton.tsx
@@ -8,7 +8,7 @@ interface DeleteArtworkButtonProps {
   artworkId: string;
 }
 
-export const DeleteArtworkButton: React.VFC<DeleteArtworkButtonProps> = ({
+export const DeleteArtworkButton: React.FC<DeleteArtworkButtonProps> = ({
   artworkId,
 }) => {
   const environment = useRelayEnvironment();

--- a/front/src/components/ArtworkDetail/IllustCarousel.tsx
+++ b/front/src/components/ArtworkDetail/IllustCarousel.tsx
@@ -11,7 +11,7 @@ interface Props {
   artwork: IllustCarousel_illusts$key;
 }
 
-export const IllustCarousel: React.VFC<Props> = ({ artwork }) => {
+export const IllustCarousel: React.FC<Props> = ({ artwork }) => {
   const { illusts } = useFragment<IllustCarousel_illusts$key>(
     graphql`
       fragment IllustCarousel_illusts on Artwork {

--- a/front/src/components/ArtworkDetail/UpdateArtworkForm.tsx
+++ b/front/src/components/ArtworkDetail/UpdateArtworkForm.tsx
@@ -19,7 +19,7 @@ interface Props {
   artworkKey: UpdateArtworkForm_artwork$key;
 }
 
-export const UpdateArtworkModal: React.VFC<Props> = ({ artworkKey }) => {
+export const UpdateArtworkModal: React.FC<Props> = ({ artworkKey }) => {
   const artwork = useFragment<UpdateArtworkForm_artwork$key>(
     graphql`
       fragment UpdateArtworkForm_artwork on Artwork {

--- a/front/src/components/ArtworkInfoForm/AgeRestrictionInput.tsx
+++ b/front/src/components/ArtworkInfoForm/AgeRestrictionInput.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useArtworkInformation } from "../../hooks/useArtworkInformation";
 
-export const AgeRestrictionInput: React.VFC = () => {
+export const AgeRestrictionInput: React.FC = () => {
   const { ageRestriction, setAgeRestriction } = useArtworkInformation();
 
   return (

--- a/front/src/components/ArtworkInfoForm/CaptionInput.tsx
+++ b/front/src/components/ArtworkInfoForm/CaptionInput.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useArtworkInformation } from "../../hooks/useArtworkInformation";
 
-export const CaptionInput: React.VFC = () => {
+export const CaptionInput: React.FC = () => {
   const { caption, setCaption } = useArtworkInformation();
 
   return (

--- a/front/src/components/ArtworkInfoForm/FilesizeBar.tsx
+++ b/front/src/components/ArtworkInfoForm/FilesizeBar.tsx
@@ -6,7 +6,7 @@ interface FilesizeBarProps {
   maxFilesize: number;
 }
 
-export const FilesizeBar: React.VFC<FilesizeBarProps> = ({
+export const FilesizeBar: React.FC<FilesizeBarProps> = ({
   filesize,
   maxFilesize,
 }) => {

--- a/front/src/components/ArtworkInfoForm/SlackChannelInput.tsx
+++ b/front/src/components/ArtworkInfoForm/SlackChannelInput.tsx
@@ -14,7 +14,7 @@ const slackChannelInputQuery = graphql`
   }
 `;
 
-export const SlackChannelInput: React.VFC = () => {
+export const SlackChannelInput: React.FC = () => {
   const { slackChannel, notifySlack, setSlackChannel } =
     useUploadArtworkContext();
   const [queryRef, loadQuery] = useQueryLoader<SlackChannelInputQuery>(
@@ -49,7 +49,7 @@ export const SlackChannelInput: React.VFC = () => {
   );
 };
 
-const ChannelSuggestion: React.VFC<{
+const ChannelSuggestion: React.FC<{
   queryRef: PreloadedQuery<SlackChannelInputQuery>;
 }> = ({ queryRef }) => {
   const { allSlackChannels } = usePreloadedQuery<SlackChannelInputQuery>(

--- a/front/src/components/ArtworkInfoForm/TagsInput.tsx
+++ b/front/src/components/ArtworkInfoForm/TagsInput.tsx
@@ -23,7 +23,7 @@ const isSafari = () =>
   navigator.userAgent.includes("Safari/") &&
   navigator.userAgent.includes("Version/");
 
-export const TagsInput: React.VFC = () => {
+export const TagsInput: React.FC = () => {
   const { tags, setTags } = useArtworkInformation();
   const appendTag = useCallback(
     (newTag: string) => {
@@ -119,7 +119,7 @@ export const TagsInput: React.VFC = () => {
   );
 };
 
-const TagList: React.VFC = () => {
+const TagList: React.FC = () => {
   const { tags, setTags } = useArtworkInformation();
 
   const removeTag = (targetTag: string) => {
@@ -147,7 +147,7 @@ const TagList: React.VFC = () => {
   );
 };
 
-const TagSuggestion: React.VFC = () => {
+const TagSuggestion: React.FC = () => {
   const { allTags } = useLazyLoadQuery<TagsInputQuery>(tagsInputQuery, {});
   if (!(allTags && allTags.edges)) {
     return null;

--- a/front/src/components/ArtworkInfoForm/TitleInput.tsx
+++ b/front/src/components/ArtworkInfoForm/TitleInput.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useArtworkInformation } from "../../hooks/useArtworkInformation";
 
-export const TitleInput: React.VFC = () => {
+export const TitleInput: React.FC = () => {
   const { title, setTitle } = useArtworkInformation();
 
   return (

--- a/front/src/components/ArtworkListItem.tsx
+++ b/front/src/components/ArtworkListItem.tsx
@@ -11,7 +11,7 @@ interface ArtworkListItemProps {
   artwork: ArtworkListItem_artwork$key;
 }
 
-const Spinner: React.VFC = () => (
+const Spinner: React.FC = () => (
   <div style={{ height: 186 }}>
     <div className="d-flex justify-content-center h-100">
       <div
@@ -25,7 +25,7 @@ const Spinner: React.VFC = () => (
   </div>
 );
 
-export const ArtworkListItem: React.VFC<ArtworkListItemProps> = (props) => {
+export const ArtworkListItem: React.FC<ArtworkListItemProps> = (props) => {
   const artwork = useFragment(
     graphql`
       fragment ArtworkListItem_artwork on Artwork {

--- a/front/src/components/Footer.tsx
+++ b/front/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const Footer: React.VFC = () => {
+export const Footer: React.FC = () => {
   const builtAt = import.meta.env.VITE_BUILT_AT
     ? new Date(Number(import.meta.env.VITE_BUILT_AT) * 1000)
     : null;

--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { useLocation } from "react-router";
 import { Link } from "./Link";
 import { NavLink } from "./NavLink";
 
-export const Header: React.VFC = () => {
+export const Header: React.FC = () => {
   const ref = useRef<HTMLDivElement>(null);
   const collapseRef = useRef<Collapse | null>(null);
   const location = useLocation();

--- a/front/src/components/LoadingOverlay.tsx
+++ b/front/src/components/LoadingOverlay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import styles from "./LoadingOverlay.module.css";
 
-export const LoadingOverlay: React.VFC = () => {
+export const LoadingOverlay: React.FC = () => {
   return (
     <div className={styles.Overlay}>
       <div className="position-absolute top-50 start-50 translate-middle">

--- a/front/src/components/ShareButton.tsx
+++ b/front/src/components/ShareButton.tsx
@@ -9,7 +9,7 @@ interface ShareButtonProps {
 
 const canShare = "share" in navigator;
 
-export const ShareButton: React.VFC<ShareButtonProps> = ({ url, title }) => {
+export const ShareButton: React.FC<ShareButtonProps> = ({ url, title }) => {
   const handleClick = useCallback(() => {
     if (!canShare) {
       return;

--- a/front/src/components/SuspenseImage.tsx
+++ b/front/src/components/SuspenseImage.tsx
@@ -33,7 +33,7 @@ interface SuspenseImageProps {
   timeout?: number;
 }
 
-export const SuspenseImage: React.VFC<
+export const SuspenseImage: React.FC<
   React.DetailedHTMLProps<
     ImgHTMLAttributes<HTMLImageElement>,
     HTMLImageElement

--- a/front/src/components/TaggedArtworks/UpdateTagModal.tsx
+++ b/front/src/components/TaggedArtworks/UpdateTagModal.tsx
@@ -12,7 +12,7 @@ interface UpdateTagModalProps {
   tagKey: UpdateTagModal_tag$key;
 }
 
-export const UpdateTagModal: React.VFC<UpdateTagModalProps> = ({ tagKey }) => {
+export const UpdateTagModal: React.FC<UpdateTagModalProps> = ({ tagKey }) => {
   const tag = useFragment(
     graphql`
       fragment UpdateTagModal_tag on Tag {

--- a/front/src/components/TegakiDU/Canvas.tsx
+++ b/front/src/components/TegakiDU/Canvas.tsx
@@ -21,7 +21,7 @@ const modifierKeyPressed = (e: KeyboardEvent) => {
   }
 };
 
-export const Canvas: React.VFC<{ width: number; height: number }> = ({
+export const Canvas: React.FC<{ width: number; height: number }> = ({
   width,
   height,
 }) => {

--- a/front/src/components/TegakiDU/ColorSuggestion.tsx
+++ b/front/src/components/TegakiDU/ColorSuggestion.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export const ColorSuggestion: React.VFC = () => {
+export const ColorSuggestion: React.FC = () => {
   const colorsGrid = [
     ["#000000", "#ffffff", "#a80515", "#f1d0d0", "#4b3d38", "#eae5d5"],
     ["#384b43", "#cfeadd", "#313768", "#d5e9f3", "#800000", "#f0e0d6"],

--- a/front/src/components/TegakiDU/Sidebar.tsx
+++ b/front/src/components/TegakiDU/Sidebar.tsx
@@ -6,7 +6,7 @@ import { PaintStackContext } from "../../contexts/TegakiDU/PaintStackContext";
 import { UploadArtworkProvider } from "../../contexts/UploadArtworkContext";
 import { UploadArtworkModal } from "./UploadArtworkModal";
 
-export const Sidebar: React.VFC = () => {
+export const Sidebar: React.FC = () => {
   const {
     color,
     backgroundColor,

--- a/front/src/components/TegakiDU/UploadArtworkModal.tsx
+++ b/front/src/components/TegakiDU/UploadArtworkModal.tsx
@@ -18,7 +18,7 @@ interface Props {
   blob?: Blob;
 }
 
-export const UploadArtworkModal: React.VFC<Props> = ({ blob }) => {
+export const UploadArtworkModal: React.FC<Props> = ({ blob }) => {
   const {
     isUploading,
     showThumbnail,

--- a/front/src/components/UserDetail/UpdateInfoForm.tsx
+++ b/front/src/components/UserDetail/UpdateInfoForm.tsx
@@ -10,7 +10,7 @@ interface Props {
   account: UpdateInfoForm_account$key;
 }
 
-export const UpdateAccountModal: React.VFC<Props> = ({ account: _account }) => {
+export const UpdateAccountModal: React.FC<Props> = ({ account: _account }) => {
   const environment = useRelayEnvironment();
   const account = useFragment(
     graphql`

--- a/front/src/contexts/ArtworkInformationContext.tsx
+++ b/front/src/contexts/ArtworkInformationContext.tsx
@@ -51,7 +51,7 @@ interface ArtworkInformationProviderProps {
   children: React.ReactNode;
 }
 
-export const ArtworkInformationProvider: React.VFC<ArtworkInformationProviderProps> =
+export const ArtworkInformationProvider: React.FC<ArtworkInformationProviderProps> =
   ({
     initialTitle,
     initialCaption,

--- a/front/src/contexts/TegakiDU/DrawingContext.tsx
+++ b/front/src/contexts/TegakiDU/DrawingContext.tsx
@@ -36,7 +36,7 @@ interface DrawingProviderProps {
   children: React.ReactNode;
 }
 
-export const DrawingProvider: React.VFC<DrawingProviderProps> = ({
+export const DrawingProvider: React.FC<DrawingProviderProps> = ({
   children,
 }) => {
   const [color, setColor] = useState("#000000");

--- a/front/src/contexts/TegakiDU/PaintStackContext.tsx
+++ b/front/src/contexts/TegakiDU/PaintStackContext.tsx
@@ -41,7 +41,7 @@ interface PaintStackContextProviderProps {
   children: React.ReactNode;
 }
 
-export const PaintStackContextProvider: React.VFC<PaintStackContextProviderProps> =
+export const PaintStackContextProvider: React.FC<PaintStackContextProviderProps> =
   ({ children }) => {
     const [paints, setPaints] = useState<Drawing[]>([]);
     const {

--- a/front/src/contexts/UploadArtworkContext.tsx
+++ b/front/src/contexts/UploadArtworkContext.tsx
@@ -94,7 +94,7 @@ interface UploadArtworkProviderProps {
   children: React.ReactNode;
 }
 
-export const UploadArtworkProvider: React.VFC<UploadArtworkProviderProps> = ({
+export const UploadArtworkProvider: React.FC<UploadArtworkProviderProps> = ({
   children,
 }) => {
   const { title, caption, tags, ageRestriction } = useArtworkInformation();

--- a/front/src/pages/ArtworkDetail.tsx
+++ b/front/src/pages/ArtworkDetail.tsx
@@ -35,7 +35,7 @@ interface CaptionProps {
   caption: string;
 }
 
-const Caption: React.VFC<CaptionProps> = ({ caption }) => {
+const Caption: React.FC<CaptionProps> = ({ caption }) => {
   const lines = caption.split("\n");
 
   return (
@@ -50,7 +50,7 @@ const Caption: React.VFC<CaptionProps> = ({ caption }) => {
   );
 };
 
-const ArtworkDetail: React.VFC = () => {
+const ArtworkDetail: React.FC = () => {
   const { id = '' } = useParams<{ id: string }>();
   const { artworkWithBidirectional } = useLazyLoadQuery<ArtworkDetailQuery>(
     graphql`

--- a/front/src/pages/Index.tsx
+++ b/front/src/pages/Index.tsx
@@ -6,7 +6,7 @@ import { Link } from "../components/Link";
 import { ArtworkListItem } from "../components/ArtworkListItem";
 import type { IndexQuery } from "./__generated__/IndexQuery.graphql";
 
-export const Index: React.VFC = () => {
+export const Index: React.FC = () => {
   const { safeArtworks, activeAccounts } = useLazyLoadQuery<IndexQuery>(
     graphql`
       query IndexQuery {

--- a/front/src/pages/NotFound.tsx
+++ b/front/src/pages/NotFound.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useLocation } from 'react-router';
 
-const NotFound: React.VFC = () => {
+const NotFound: React.FC = () => {
   const location = useLocation();
   return (
     <div className="alert alert-warning">

--- a/front/src/pages/RecentArtworks.tsx
+++ b/front/src/pages/RecentArtworks.tsx
@@ -28,7 +28,7 @@ const useRatingParam = (): [string, ArtworkRatingEnum[]] => {
   }
 };
 
-const ArtworkList: React.VFC<{
+const ArtworkList: React.FC<{
   artworks: RecentArtworks_artworks$key;
 }> = ({ artworks: queryRef }) => {
   const {
@@ -101,7 +101,7 @@ const ArtworkList: React.VFC<{
   );
 };
 
-export const RecentArtworks: React.VFC = () => {
+export const RecentArtworks: React.FC = () => {
   const [selectedRating, rating] = useRatingParam();
   const artworks = useLazyLoadQuery<RecentArtworksQuery>(
     graphql`

--- a/front/src/pages/RedirectFolderToArtwork.tsx
+++ b/front/src/pages/RedirectFolderToArtwork.tsx
@@ -5,7 +5,7 @@ import { Navigate, useParams } from 'react-router';
 
 import { RedirectFolderToArtworkQuery } from "./__generated__/RedirectFolderToArtworkQuery.graphql";
 
-export const RedirectFolderToArtwork: React.VFC = () => {
+export const RedirectFolderToArtwork: React.FC = () => {
   const { folder_id = '0' } = useParams<{ folder_id: string }>();
   const { artworkByFolderId: artwork } =
     useLazyLoadQuery<RedirectFolderToArtworkQuery>(

--- a/front/src/pages/RedirectToMyPage.tsx
+++ b/front/src/pages/RedirectToMyPage.tsx
@@ -4,7 +4,7 @@ import { Navigate } from 'react-router';
 
 import type { RedirectToMyPageQuery } from "./__generated__/RedirectToMyPageQuery.graphql";
 
-export const RedirectToMyPage: React.VFC = () => {
+export const RedirectToMyPage: React.FC = () => {
   const { viewer } = useLazyLoadQuery<RedirectToMyPageQuery>(
     graphql`
       query RedirectToMyPageQuery {

--- a/front/src/pages/TaggedArtworks.tsx
+++ b/front/src/pages/TaggedArtworks.tsx
@@ -7,7 +7,7 @@ import { ArtworkListItem } from "../components/ArtworkListItem";
 import { UpdateTagModal } from "../components/TaggedArtworks/UpdateTagModal";
 import { TaggedArtworksQuery } from "./__generated__/TaggedArtworksQuery.graphql";
 
-export const TaggedArtworks: React.VFC = () => {
+export const TaggedArtworks: React.FC = () => {
   const { tag = '' } = useParams<{ tag: string }>();
   // NOTE: # などの文字列がパーセントエンコードされているのでデコードしておく
   const decodedTag = decodeURIComponent(tag);
@@ -23,7 +23,7 @@ export const TaggedArtworks: React.VFC = () => {
   return <Inner tag={decodedTag} />;
 };
 
-const Inner: React.VFC<{ tag: string }> = ({ tag }) => {
+const Inner: React.FC<{ tag: string }> = ({ tag }) => {
   const { tagByName, taggedArtworks } = useLazyLoadQuery<TaggedArtworksQuery>(
     graphql`
       query TaggedArtworksQuery($tag: String!) {

--- a/front/src/pages/Tags.tsx
+++ b/front/src/pages/Tags.tsx
@@ -5,7 +5,7 @@ import { Link } from "../components/Link";
 
 import { TagsQuery } from "./__generated__/TagsQuery.graphql";
 
-export const Tags: React.VFC = () => {
+export const Tags: React.FC = () => {
   const { allTags } = useLazyLoadQuery<TagsQuery>(
     graphql`
       query TagsQuery {

--- a/front/src/pages/TegakiDU.tsx
+++ b/front/src/pages/TegakiDU.tsx
@@ -7,7 +7,7 @@ import { Sidebar } from "../components/TegakiDU/Sidebar";
 import { DrawingProvider } from "../contexts/TegakiDU/DrawingContext";
 import { PaintStackContextProvider } from "../contexts/TegakiDU/PaintStackContext";
 
-const TegakiDU: React.VFC = () => {
+const TegakiDU: React.FC = () => {
   const [ref, { width, height }] = useMeasure<HTMLDivElement>();
 
   return (

--- a/front/src/pages/UploadArtwork.tsx
+++ b/front/src/pages/UploadArtwork.tsx
@@ -35,7 +35,7 @@ import { useArtworkInformation } from "../hooks/useArtworkInformation";
 import { useUploadArtworkContext } from "../hooks/useUploadArtworkContext";
 import { UploadArtworkQuery } from "./__generated__/UploadArtworkQuery.graphql";
 
-export const UploadArtwork: React.VFC = () => {
+export const UploadArtwork: React.FC = () => {
   return (
     <ArtworkInformationProvider>
       <UploadArtworkProvider>
@@ -295,7 +295,7 @@ const UploadArtworkForm = () => {
   );
 };
 
-const SortableImage: React.VFC<{
+const SortableImage: React.FC<{
   index: number;
   dataURL: string;
   handleDeleteImage: (i: number) => void;

--- a/front/src/pages/UserDetail.tsx
+++ b/front/src/pages/UserDetail.tsx
@@ -10,7 +10,7 @@ import { ArtworkListPaginationQuery } from "./__generated__/ArtworkListPaginatio
 import { UserDetailQuery } from "./__generated__/UserDetailQuery.graphql";
 import { UserDetail_artworks$key } from "./__generated__/UserDetail_artworks.graphql";
 
-export const UserDetail: React.VFC = () => {
+export const UserDetail: React.FC = () => {
   const { kmcid = '' } = useParams<{ kmcid: string }>();
   const { user } = useLazyLoadQuery<UserDetailQuery>(
     graphql`
@@ -46,7 +46,7 @@ export const UserDetail: React.VFC = () => {
   );
 };
 
-const ArtworkList: React.VFC<{ user: UserDetail_artworks$key }> = ({
+const ArtworkList: React.FC<{ user: UserDetail_artworks$key }> = ({
   user,
 }) => {
   const {


### PR DESCRIPTION
## 概要

deprecated になった `React.VFC`（VoidFunctionComponent）を `React.FC`（FunctionComponent）に移行します。

## 背景

- `React.VFC` は React 17 で deprecated となり、React 18 の型定義から削除されました
- React 18 では `React.FC` から暗黙的な `children` prop が削除されたため、`React.VFC` と `React.FC` の挙動が同等になりました
- そのため、すべての `React.VFC` を `React.FC` に単純置換できます

## 変更内容

- `front/src` 配下の `.tsx` ファイル 39ファイル・50箇所の `React.VFC` を `React.FC` に置換

## テスト

- `grep -r "React.VFC" front/src/` で残存がないことを確認済み
- `tsc --noEmit` でコンパイルエラーがないことを確認済み

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgtjRkfczcDpRynyUupXwW)_