### PR TITLE
react-bootstrapを使うように実装を移行

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -24,6 +24,7 @@
         "clsx": "^1.1.1",
         "konva": "^8.0.4",
         "react": "^19.0.0",
+        "react-bootstrap": "^2.10.10",
         "react-dom": "^19.0.0",
         "react-helmet": "^6.1.0",
         "react-konva": "^19.0.0",
@@ -3535,6 +3536,33 @@
         }
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
+      "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.6.tgz",
+      "integrity": "sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.8.tgz",
+      "integrity": "sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3770,11 +3798,39 @@
       "license": "MIT"
     },
     "node_modules/@popperjs/core": {
-      "version": "2.9.2",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.10.0.tgz",
+      "integrity": "sha512-mnelvACtfNWWKFCT1YHebxJRmfBmmANGwHQhCFPByMVTx1L8RumcaLxChYkE87g2KPuP5xX2il/oRn1DytW+qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "3.48.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.34.0.tgz",
+      "integrity": "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@repeaterjs/repeater": {
@@ -3783,6 +3839,60 @@
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
+      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@popperjs/core": "^2.11.8",
+        "@react-aria/ssr": "^3.5.0",
+        "@restart/hooks": "^0.5.0",
+        "@types/warning": "^3.0.3",
+        "dequal": "^2.0.3",
+        "dom-helpers": "^5.2.0",
+        "uncontrollable": "^8.0.4",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/@restart/hooks": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
+      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@restart/ui/node_modules/uncontrollable": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
+      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.14.0"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
@@ -4210,6 +4320,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -4422,6 +4547,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -4467,6 +4598,15 @@
         "@types/relay-runtime": "*"
       }
     },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/relay-runtime": {
       "version": "20.1.1",
       "resolved": "https://registry.npmjs.org/@types/relay-runtime/-/relay-runtime-20.1.1.tgz",
@@ -4492,6 +4632,12 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
+      "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==",
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -5050,6 +5196,18 @@
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aria-query": {
@@ -5907,6 +6065,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -6476,7 +6640,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6547,6 +6710,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/domain-browser": {
       "version": "4.22.0",
@@ -10670,6 +10843,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prop-types-extra": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
+      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^16.3.2",
+        "warning": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
+      }
+    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -10771,6 +10957,67 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.48.0.tgz",
+      "integrity": "sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.46.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-bootstrap": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
+      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "@restart/hooks": "^0.4.9",
+        "@restart/ui": "^1.9.4",
+        "@types/prop-types": "^15.7.12",
+        "@types/react-transition-group": "^4.4.6",
+        "classnames": "^2.3.2",
+        "dom-helpers": "^5.2.1",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "prop-types-extra": "^1.1.0",
+        "react-transition-group": "^4.4.5",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.8",
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
@@ -10844,6 +11091,12 @@
         "react-dom": "^19.2.0"
       }
     },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
     "node_modules/react-reconciler": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
@@ -10903,6 +11156,23 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/react-stately": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.46.0.tgz",
+      "integrity": "sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@internationalized/number": "^3.6.6",
+        "@internationalized/string": "^3.2.8",
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-string-replace": {
       "version": "0.4.4",
       "license": "MIT",
@@ -10911,6 +11181,22 @@
       },
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/react-universal-interface": {
@@ -12451,6 +12737,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -12564,6 +12865,15 @@
       "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -12814,6 +13124,15 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/front/package.json
+++ b/front/package.json
@@ -19,6 +19,7 @@
     "clsx": "^1.1.1",
     "konva": "^8.0.4",
     "react": "^19.0.0",
+    "react-bootstrap": "^2.10.10",
     "react-dom": "^19.0.0",
     "react-helmet": "^6.1.0",
     "react-konva": "^19.0.0",

--- a/front/src/components/ArtworkDetail/ArtworkComment.tsx
+++ b/front/src/components/ArtworkDetail/ArtworkComment.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from "react";
+import { Button, Form, ListGroup, Spinner } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment, useRelayEnvironment } from "react-relay";
 
@@ -39,7 +40,7 @@ export const ArtworkComment: React.FC<Props> = ({ artwork }) => {
 
   return (
     <div className="mt-2">
-      <ul className="list-group">
+      <ListGroup>
         {edges.map((edge, i) => {
           if (!edge) {
             return null;
@@ -51,16 +52,16 @@ export const ArtworkComment: React.FC<Props> = ({ artwork }) => {
           }
 
           return (
-            <li key={i} className="list-group-item d-flex align-items-start">
+            <ListGroup.Item key={i} className="d-flex align-items-start">
               <div className="ms2 me-auto">
                 <div className="fw-bold">{node.account?.kmcid}</div>
                 {node.text}
               </div>
               {node.createdAt}
-            </li>
+            </ListGroup.Item>
           );
         })}
-      </ul>
+      </ListGroup>
       <div className="mt-2">
         <CommentForm artworkId={artworkId} connectionId={comments.__id} />
       </div>
@@ -104,27 +105,24 @@ const CommentForm: React.FC<{ artworkId: string; connectionId: string }> = ({
     <form onSubmit={handleSubmit}>
       <div className="row g-3">
         <div className="col-sm-9">
-          <input
+          <Form.Control
             type="text"
             id="text"
             value={text}
             onChange={(e) => setText(e.target.value)}
             required
-            className="form-control"
           />
         </div>
         <div className="col-sm-3">
-          <input
-            type="submit"
-            value="コメントする"
-            className="btn btn-primary form-control"
-          />
+          <Button type="submit" variant="primary" className="w-100">
+            コメントする
+          </Button>
         </div>
         {isPosting && (
           <div className="col-sm-1 text-center">
-            <div className="spinner-border text-primary" role="status">
+            <Spinner animation="border" variant="primary" role="status">
               <span className="visually-hidden">Uploading...</span>
-            </div>
+            </Spinner>
           </div>
         )}
       </div>

--- a/front/src/components/ArtworkDetail/ArtworkLikeList.tsx
+++ b/front/src/components/ArtworkDetail/ArtworkLikeList.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from "react";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment, useRelayEnvironment } from "react-relay";
 
-import { useTooltip } from "../../hooks/useTooltip";
 import { commitLikeArtworkMutation } from "../../mutation/LikeArtwork";
 import { Link } from "../Link";
 import type { ArtworkLikeList_likes$key } from "./__generated__/ArtworkLikeList_likes.graphql";
@@ -49,25 +49,27 @@ export const LikeList: React.FC<Props> = ({ artwork }) => {
     [artworkId, environment, likes],
   );
 
-  const buttonRef = useTooltip<HTMLButtonElement>();
-
   if (!(likes && likes.edges)) {
     return null;
   }
 
   return (
     <div>
-      <button
-        className="btn btn-sm btn-outline-secondary"
-        ref={buttonRef}
-        data-bs-toggle="tooltip"
-        data-bs-placement="top"
-        data-bs-html="true"
-        title={`<i class="bi bi-heart-fill"></i> をつける`}
-        onClick={handleClickLikeButton}
+      <OverlayTrigger
+        placement="top"
+        overlay={
+          <Tooltip>
+            <i className="bi bi-heart-fill"></i> をつける
+          </Tooltip>
+        }
       >
-        +<i className="bi bi-heart-fill"></i>
-      </button>{" "}
+        <button
+          className="btn btn-sm btn-outline-secondary"
+          onClick={handleClickLikeButton}
+        >
+          +<i className="bi bi-heart-fill"></i>
+        </button>
+      </OverlayTrigger>{" "}
       {likes.edges.map((edge, i) => {
         if (!edge) {
           return null;
@@ -96,21 +98,18 @@ interface LikeIconProps {
 }
 
 const LikeIcon: React.FC<LikeIconProps> = ({ like }) => {
-  const ref = useTooltip<HTMLAnchorElement>();
-
   if (!like.account) {
     return null;
   }
 
   return (
-    <Link
-      to={`/users/${like.account.kmcid}`}
-      data-bs-toggle="tooltip"
-      data-bs-placement="top"
-      title={like.account.kmcid}
-      ref={ref}
+    <OverlayTrigger
+      placement="top"
+      overlay={<Tooltip>{like.account.kmcid}</Tooltip>}
     >
-      <i className="bi bi-heart-fill"></i>
-    </Link>
+      <Link to={`/users/${like.account.kmcid}`}>
+        <i className="bi bi-heart-fill"></i>
+      </Link>
+    </OverlayTrigger>
   );
 };

--- a/front/src/components/ArtworkDetail/DeleteArtworkButton.tsx
+++ b/front/src/components/ArtworkDetail/DeleteArtworkButton.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Button } from "react-bootstrap";
 import { useRelayEnvironment } from "react-relay";
 import { useNavigate } from "react-router";
 
@@ -31,8 +32,8 @@ export const DeleteArtworkButton: React.FC<DeleteArtworkButtonProps> = ({
   };
 
   return (
-    <button className="btn btn-danger" onClick={handleDeleteButtonClick}>
+    <Button variant="danger" onClick={handleDeleteButtonClick}>
       この神絵を削除する
-    </button>
+    </Button>
   );
 };

--- a/front/src/components/ArtworkDetail/IllustCarousel.tsx
+++ b/front/src/components/ArtworkDetail/IllustCarousel.tsx
@@ -1,6 +1,6 @@
-import { Carousel } from "bootstrap";
 import clsx from "clsx";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
+import { Carousel } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment } from "react-relay";
 
@@ -30,45 +30,10 @@ export const IllustCarousel: React.FC<Props> = ({ artwork }) => {
     artwork,
   );
   const [index, setIndex] = useState(0);
-  const carouselElementRef = useRef<HTMLDivElement>(null);
-  const carouselRef = useRef<Carousel | null>(null);
 
   useEffect(() => {
     // reset carousel index
     setIndex(0);
-  }, [illusts]);
-
-  useEffect(() => {
-    if (!carouselElementRef.current) {
-      return;
-    }
-    carouselRef.current = new Carousel(carouselElementRef.current, {
-      pause: true,
-      wrap: false,
-    });
-
-    return () => {
-      carouselRef.current?.dispose();
-    };
-  });
-
-  const handleNext = useCallback(() => {
-    setIndex((currentIndex) => {
-      const newIndex = Math.max(0, currentIndex + 1);
-      if (currentIndex !== newIndex) {
-        carouselRef.current?.next();
-      }
-      return newIndex;
-    });
-  }, []);
-  const handlePrevious = useCallback(() => {
-    setIndex((currentIndex) => {
-      const newIndex = Math.min(currentIndex - 1, illusts?.edges.length || 0);
-      if (currentIndex !== newIndex) {
-        carouselRef.current?.prev();
-      }
-      return newIndex;
-    });
   }, [illusts]);
 
   if (!(illusts && illusts.edges)) {
@@ -77,64 +42,40 @@ export const IllustCarousel: React.FC<Props> = ({ artwork }) => {
 
   return (
     <>
-      <div className="carousel carousel-dark slide" ref={carouselElementRef}>
-        <div className="carousel-inner">
-          {illusts?.edges.map((edge, i) => {
-            if (!edge) {
-              return null;
-            }
-            const node = edge.node;
-            if (!node) {
-              return null;
-            }
+      <Carousel
+        activeIndex={index}
+        onSelect={(i) => setIndex(i)}
+        variant="dark"
+        wrap={false}
+        indicators={false}
+        interval={null}
+      >
+        {illusts.edges.map((edge, i) => {
+          if (!edge) {
+            return null;
+          }
+          const node = edge.node;
+          if (!node) {
+            return null;
+          }
 
-            return (
-              <div
-                className={clsx("carousel-item", i === 0 && "active")}
-                key={i}
-              >
-                <picture>
-                  <source
-                    srcSet={node.webpUrl}
-                    className="mw-100 d-block mx-auto"
-                  />
-                  <img
-                    src={node.imageUrl}
-                    alt=""
-                    className="mw-100 d-block mx-auto"
-                  />
-                </picture>
-              </div>
-            );
-          })}
-        </div>
-        {index > 0 && (
-          <button
-            className="carousel-control-prev"
-            type="button"
-            onClick={handlePrevious}
-          >
-            <span
-              className="carousel-control-prev-icon"
-              aria-hidden="true"
-            ></span>
-            <span className="visually-hidden">Previous</span>
-          </button>
-        )}
-        {index < illusts.edges.length - 1 && (
-          <button
-            className="carousel-control-next"
-            type="button"
-            onClick={handleNext}
-          >
-            <span
-              className="carousel-control-next-icon"
-              aria-hidden="true"
-            ></span>
-            <span className="visually-hidden">Next</span>
-          </button>
-        )}
-      </div>
+          return (
+            <Carousel.Item key={i}>
+              <picture>
+                <source
+                  srcSet={node.webpUrl}
+                  className="mw-100 d-block mx-auto"
+                />
+                <img
+                  src={node.imageUrl}
+                  alt=""
+                  className="mw-100 d-block mx-auto"
+                />
+              </picture>
+            </Carousel.Item>
+          );
+        })}
+      </Carousel>
       {illusts.edges.length >= 2 && (
         <div className="mt-2 d-flex justify-content-center">
           {illusts.edges.map((edge, i) => {
@@ -155,7 +96,6 @@ export const IllustCarousel: React.FC<Props> = ({ artwork }) => {
                 onClick={(e) => {
                   e.preventDefault();
                   setIndex(i);
-                  carouselRef.current?.to(i);
                 }}
               >
                 <SuspenseImage

--- a/front/src/components/ArtworkDetail/UpdateArtworkForm.tsx
+++ b/front/src/components/ArtworkDetail/UpdateArtworkForm.tsx
@@ -1,5 +1,5 @@
-import { Modal } from "bootstrap";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useState } from "react";
+import { Button, Modal } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment, useRelayEnvironment } from "react-relay";
 
@@ -58,7 +58,8 @@ export const UpdateArtworkModal: React.FC<Props> = ({ artworkKey }) => {
     setAgeRestriction,
   } = useArtworkInformation();
 
-  const ref = useRef<HTMLDivElement>(null);
+  const [show, setShow] = useState(false);
+
   const resetStates = useCallback(() => {
     // explicitly reset values
     setTitle(artwork.title || "");
@@ -76,16 +77,9 @@ export const UpdateArtworkModal: React.FC<Props> = ({ artworkKey }) => {
     setTitle,
   ]);
 
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) {
-      return;
-    }
-
-    el.addEventListener("hidden.bs.modal", resetStates);
-    return () => {
-      el.removeEventListener("hidden.bs.modal", resetStates);
-    };
+  const handleHide = useCallback(() => {
+    setShow(false);
+    resetStates();
   }, [resetStates]);
 
   const handleUpdate = useCallback(
@@ -105,8 +99,7 @@ export const UpdateArtworkModal: React.FC<Props> = ({ artworkKey }) => {
           },
         },
         onCompleted: () => {
-          const modal = Modal.getInstance(ref.current!);
-          modal?.hide();
+          setShow(false);
         },
       });
     },
@@ -115,54 +108,35 @@ export const UpdateArtworkModal: React.FC<Props> = ({ artworkKey }) => {
 
   return (
     <>
-      <div
-        className="modal fade"
-        id="updateArtworkModal"
-        aria-hidden="true"
-        ref={ref}
-      >
-        <div className="modal-dialog modal-xl">
-          <div className="modal-content">
-            <form onSubmit={handleUpdate}>
-              <div className="modal-header">
-                <h5 className="modal-title">神絵の情報編集</h5>
-                <button
-                  type="button"
-                  className="btn-close"
-                  aria-label="閉じる"
-                  data-bs-dismiss="modal"
-                ></button>
-              </div>
-              <div className="modal-body">
-                <div className="mb-3">
-                  <TitleInput />
-                </div>
-                <div className="mb-3">
-                  <CaptionInput />
-                </div>
-                <div className="mb-3">
-                  <TagsInput />
-                </div>
-                <div className="mb-3">
-                  <AgeRestrictionInput />
-                </div>
-              </div>
-              <div className="modal-footer">
-                <button type="submit" className="btn btn-primary form-control">
-                  保存する
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      </div>
-      <button
-        className="btn btn-primary"
-        data-bs-toggle="modal"
-        data-bs-target="#updateArtworkModal"
-      >
+      <Button variant="primary" onClick={() => setShow(true)}>
         情報の編集
-      </button>
+      </Button>
+      <Modal show={show} onHide={handleHide} size="xl">
+        <form onSubmit={handleUpdate}>
+          <Modal.Header closeButton>
+            <Modal.Title>神絵の情報編集</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div className="mb-3">
+              <TitleInput />
+            </div>
+            <div className="mb-3">
+              <CaptionInput />
+            </div>
+            <div className="mb-3">
+              <TagsInput />
+            </div>
+            <div className="mb-3">
+              <AgeRestrictionInput />
+            </div>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button type="submit" variant="primary" className="w-100">
+              保存する
+            </Button>
+          </Modal.Footer>
+        </form>
+      </Modal>
     </>
   );
 };

--- a/front/src/components/ArtworkInfoForm/AgeRestrictionInput.tsx
+++ b/front/src/components/ArtworkInfoForm/AgeRestrictionInput.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Col, Form, Row } from "react-bootstrap";
 
 import { useArtworkInformation } from "../../hooks/useArtworkInformation";
 
@@ -6,54 +7,42 @@ export const AgeRestrictionInput: React.FC = () => {
   const { ageRestriction, setAgeRestriction } = useArtworkInformation();
 
   return (
-    <div className="form-group row">
-      <div className="col-sm-2">
+    <Form.Group as={Row}>
+      <Col sm={2}>
         年齢制限 <span className="text-danger">(必須)</span>
-      </div>
-      <div className="col-sm-10">
-        <div className="form-check form-check-inline">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="age_restriction"
-            required
-            id="age_restriction_safe"
-            checked={ageRestriction === "SAFE"}
-            onChange={() => setAgeRestriction("SAFE")}
-          />
-          <label className="form-check-label" htmlFor="age_restriction_safe">
-            全年齢
-          </label>
-        </div>
-        <div className="form-check form-check-inline">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="age_restriction"
-            required
-            id="age_restriction_r_18"
-            checked={ageRestriction === "R-18"}
-            onChange={() => setAgeRestriction("R-18")}
-          />
-          <label className="form-check-label" htmlFor="age_restriction_r_18">
-            R-18
-          </label>
-        </div>
-        <div className="form-check form-check-inline">
-          <input
-            className="form-check-input"
-            type="radio"
-            name="age_restriction"
-            required
-            id="age_restriction_r_18g"
-            checked={ageRestriction === "R-18G"}
-            onChange={() => setAgeRestriction("R-18G")}
-          />
-          <label className="form-check-label" htmlFor="age_restriction_r_18g">
-            R-18G
-          </label>
-        </div>
-      </div>
-    </div>
+      </Col>
+      <Col sm={10}>
+        <Form.Check
+          inline
+          type="radio"
+          name="age_restriction"
+          required
+          id="age_restriction_safe"
+          label="全年齢"
+          checked={ageRestriction === "SAFE"}
+          onChange={() => setAgeRestriction("SAFE")}
+        />
+        <Form.Check
+          inline
+          type="radio"
+          name="age_restriction"
+          required
+          id="age_restriction_r_18"
+          label="R-18"
+          checked={ageRestriction === "R-18"}
+          onChange={() => setAgeRestriction("R-18")}
+        />
+        <Form.Check
+          inline
+          type="radio"
+          name="age_restriction"
+          required
+          id="age_restriction_r_18g"
+          label="R-18G"
+          checked={ageRestriction === "R-18G"}
+          onChange={() => setAgeRestriction("R-18G")}
+        />
+      </Col>
+    </Form.Group>
   );
 };

--- a/front/src/components/ArtworkInfoForm/CaptionInput.tsx
+++ b/front/src/components/ArtworkInfoForm/CaptionInput.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Form } from "react-bootstrap";
 
 import { useArtworkInformation } from "../../hooks/useArtworkInformation";
 
@@ -7,12 +8,10 @@ export const CaptionInput: React.FC = () => {
 
   return (
     <>
-      <label htmlFor="caption" className="form-label">
-        キャプション
-      </label>
-      <textarea
+      <Form.Label htmlFor="caption">キャプション</Form.Label>
+      <Form.Control
+        as="textarea"
         id="caption"
-        className="form-control"
         value={caption}
         onChange={(e) => setCaption(e.target.value)}
       />

--- a/front/src/components/ArtworkInfoForm/FilesizeBar.tsx
+++ b/front/src/components/ArtworkInfoForm/FilesizeBar.tsx
@@ -1,5 +1,5 @@
-import clsx from "clsx";
-import { useMemo } from "react";
+import React, { useMemo } from "react";
+import { ProgressBar } from "react-bootstrap";
 
 interface FilesizeBarProps {
   filesize: number;
@@ -16,17 +16,10 @@ export const FilesizeBar: React.FC<FilesizeBarProps> = ({
   );
 
   return (
-    <div className="progress">
-      <div
-        className={clsx("progress-bar", ratio >= 100 && "bg-danger")}
-        role="progressbar"
-        style={{ width: `${ratio}%` }}
-        aria-valuenow={ratio}
-        aria-valuemin={0}
-        aria-valuemax={100}
-      >
-        {ratio}%
-      </div>
-    </div>
+    <ProgressBar
+      now={ratio}
+      label={`${ratio}%`}
+      variant={ratio >= 100 ? "danger" : undefined}
+    />
   );
 };

--- a/front/src/components/ArtworkInfoForm/SlackChannelInput.tsx
+++ b/front/src/components/ArtworkInfoForm/SlackChannelInput.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, Suspense } from "react";
+import { Form } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { PreloadedQuery, usePreloadedQuery, useQueryLoader } from "react-relay";
 
@@ -27,12 +28,13 @@ export const SlackChannelInput: React.FC = () => {
 
   return (
     <>
-      <label htmlFor="channel_id">投稿先のチャンネル(迷惑厳禁！)</label>
+      <Form.Label htmlFor="channel_id">
+        投稿先のチャンネル(迷惑厳禁！)
+      </Form.Label>
       <div className="row g-2">
         <div className="col-lg">
-          <select
+          <Form.Select
             id="channel_id"
-            className="form-select"
             value={slackChannel}
             disabled={!notifySlack}
             onChange={(e) => setSlackChannel(e.target.value)}
@@ -42,7 +44,7 @@ export const SlackChannelInput: React.FC = () => {
                 <ChannelSuggestion queryRef={queryRef} />
               )}
             </Suspense>
-          </select>
+          </Form.Select>
         </div>
       </div>
     </>

--- a/front/src/components/ArtworkInfoForm/TagsInput.tsx
+++ b/front/src/components/ArtworkInfoForm/TagsInput.tsx
@@ -91,9 +91,7 @@ export const TagsInput: React.FC = () => {
         <TagList />
         <div className="col-lg">
           <div className="input-group">
-            <div className="input-group-prepend">
-              <span className="input-group-text">#</span>
-            </div>
+            <span className="input-group-text">#</span>
             <input
               type="text"
               id="tags"

--- a/front/src/components/ArtworkInfoForm/TitleInput.tsx
+++ b/front/src/components/ArtworkInfoForm/TitleInput.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Form } from "react-bootstrap";
 
 import { useArtworkInformation } from "../../hooks/useArtworkInformation";
 
@@ -7,13 +8,12 @@ export const TitleInput: React.FC = () => {
 
   return (
     <>
-      <label htmlFor="title" className="form-label">
+      <Form.Label htmlFor="title">
         タイトル <span className="text-danger">(必須)</span>
-      </label>
-      <input
+      </Form.Label>
+      <Form.Control
         type="text"
         id="title"
-        className="form-control"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         required

--- a/front/src/components/ArtworkListItem.tsx
+++ b/front/src/components/ArtworkListItem.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense } from "react";
+import { Card, Spinner } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment } from "react-relay/hooks";
 
@@ -11,17 +12,11 @@ interface ArtworkListItemProps {
   artwork: ArtworkListItem_artwork$key;
 }
 
-const Spinner: React.FC = () => (
-  <div style={{ height: 186 }}>
-    <div className="d-flex justify-content-center h-100">
-      <div
-        className="spinner-border"
-        role="status"
-        style={{ width: 80, height: 80 }}
-      >
-        <span className="visually-hidden">Loading...</span>
-      </div>
-    </div>
+const LoadingSpinner: React.FC = () => (
+  <div style={{ height: 186 }} className="d-flex justify-content-center h-100">
+    <Spinner animation="border" role="status" style={{ width: 80, height: 80 }}>
+      <span className="visually-hidden">Loading...</span>
+    </Spinner>
   </div>
 );
 
@@ -50,8 +45,8 @@ export const ArtworkListItem: React.FC<ArtworkListItemProps> = (props) => {
   }
 
   return (
-    <div className="card p-1" style={{ height: 320 }}>
-      <Suspense fallback={<Spinner />}>
+    <Card className="p-1" style={{ height: 320 }}>
+      <Suspense fallback={<LoadingSpinner />}>
         <SuspenseImage
           src={
             artwork.nsfw
@@ -68,7 +63,7 @@ export const ArtworkListItem: React.FC<ArtworkListItemProps> = (props) => {
           className="card-img-top mx-auto my-0"
         />
       </Suspense>
-      <div className="card-body">
+      <Card.Body>
         <h3 className="text-truncate">
           <Link
             to={`/artwork/${artwork.id}`}
@@ -77,9 +72,11 @@ export const ArtworkListItem: React.FC<ArtworkListItemProps> = (props) => {
             {artwork.title}
           </Link>
         </h3>
-        {account && <p className="card-text text-truncate">{account.name}</p>}
-        <p className="card-text text-truncate">{artwork.caption}</p>
-      </div>
-    </div>
+        {account && (
+          <Card.Text className="text-truncate">{account.name}</Card.Text>
+        )}
+        <Card.Text className="text-truncate">{artwork.caption}</Card.Text>
+      </Card.Body>
+    </Card>
   );
 };

--- a/front/src/components/ErrorBoundary.tsx
+++ b/front/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
+import { Alert } from "react-bootstrap";
 
 interface State {
   error?: any;
@@ -18,7 +19,9 @@ export class ErrorBoundary extends React.Component<any, State> {
   render() {
     if (this.state.error) {
       return (
-        <pre className="alert alert-danger">{this.state.error.toString()}</pre>
+        <Alert variant="danger">
+          <pre>{this.state.error.toString()}</pre>
+        </Alert>
       );
     }
 

--- a/front/src/components/Footer.tsx
+++ b/front/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Container } from "react-bootstrap";
 
 export const Footer: React.FC = () => {
   const builtAt = import.meta.env.VITE_BUILT_AT
@@ -9,7 +10,7 @@ export const Footer: React.FC = () => {
 
   return (
     <footer className="mt-3 py-3">
-      <div className="container">
+      <Container>
         <div className="text-muted">
           Goduploader-graphql
           {builtAt && ` (built at ${builtAt.toLocaleString()})`}
@@ -27,7 +28,7 @@ export const Footer: React.FC = () => {
             </>
           )}
         </div>
-      </div>
+      </Container>
     </footer>
   );
 };

--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -1,52 +1,35 @@
-import { Collapse } from "bootstrap";
-import React, { useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
+import { Container, Navbar } from "react-bootstrap";
 import { useLocation } from "react-router";
 
 import { Link } from "./Link";
 import { NavLink } from "./NavLink";
 
 export const Header: React.FC = () => {
-  const ref = useRef<HTMLDivElement>(null);
-  const collapseRef = useRef<Collapse | null>(null);
+  const [expanded, setExpanded] = useState(false);
   const location = useLocation();
-
-  useEffect(() => {
-    if (!ref.current) return;
-    collapseRef.current = new Collapse(ref.current, { toggle: false });
-    return () => {
-      collapseRef.current?.dispose();
-      collapseRef.current = null;
-    };
-  }, []);
 
   // ページ遷移時にドロップダウンメニューが閉じるようにする
   useEffect(() => {
-    collapseRef.current?.hide();
+    setExpanded(false);
   }, [location]);
 
   return (
-    <nav className="navbar navbar-expand-xl navbar-light bg-light mb-3">
-      <div className="container">
-        <Link className="navbar-brand" to="/">
+    <Navbar
+      expand="xl"
+      bg="light"
+      variant="light"
+      className="mb-3"
+      expanded={expanded}
+      onToggle={setExpanded}
+    >
+      <Container>
+        <Navbar.Brand as={Link} to="/">
           <span className="d-none d-md-inline">KMC画像アップローダー </span>
           God Illust Uploader
-        </Link>
-        <button
-          className="navbar-toggler"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#navbarSupportedContent"
-          aria-controls="navbarSupportedContent"
-          aria-expanded="false"
-          aria-label="Toggle navigation"
-        >
-          <span className="navbar-toggler-icon"></span>
-        </button>
-        <div
-          className="collapse navbar-collapse"
-          id="navbarSupportedContent"
-          ref={ref}
-        >
+        </Navbar.Brand>
+        <Navbar.Toggle aria-controls="navbarSupportedContent" />
+        <Navbar.Collapse id="navbarSupportedContent">
           <ul className="navbar-nav me-auto mb-2 mb-lg-0">
             <li className="nav-item">
               <NavLink
@@ -89,8 +72,8 @@ export const Header: React.FC = () => {
               </NavLink>
             </li>
           </ul>
-        </div>
-      </div>
-    </nav>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
   );
 };

--- a/front/src/components/ShareButton.tsx
+++ b/front/src/components/ShareButton.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { Button } from "react-bootstrap";
 
 import styles from "./ShareButton.module.css";
 
@@ -23,11 +24,8 @@ export const ShareButton: React.FC<ShareButtonProps> = ({ url, title }) => {
   }
 
   return (
-    <button
-      className={`btn btn-info ${styles.container}`}
-      onClick={handleClick}
-    >
+    <Button variant="info" className={styles.container} onClick={handleClick}>
       シェアする
-    </button>
+    </Button>
   );
 };

--- a/front/src/components/TaggedArtworks/UpdateTagModal.tsx
+++ b/front/src/components/TaggedArtworks/UpdateTagModal.tsx
@@ -1,5 +1,5 @@
-import { Modal } from "bootstrap";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useState } from "react";
+import { Alert, Button, Form, Modal } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment, useRelayEnvironment } from "react-relay";
 import { useNavigate } from "react-router";
@@ -23,24 +23,16 @@ export const UpdateTagModal: React.FC<UpdateTagModalProps> = ({ tagKey }) => {
     `,
     tagKey,
   );
+  const [show, setShow] = useState(false);
   const [name, setName] = useState(tag.name);
 
   const resetStates = useCallback(() => {
     setName(tag.name);
   }, [tag.name]);
 
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) {
-      return;
-    }
-
-    el.addEventListener("hidden.bs.modal", resetStates);
-    return () => {
-      el.removeEventListener("hidden.bs.modal", resetStates);
-    };
+  const handleHide = useCallback(() => {
+    setShow(false);
+    resetStates();
   }, [resetStates]);
 
   const [errors, setErrors] = useState<PayloadError[] | null | undefined>(null);
@@ -57,17 +49,12 @@ export const UpdateTagModal: React.FC<UpdateTagModalProps> = ({ tagKey }) => {
           },
         },
         onCompleted: (response, errors) => {
-          if (!ref.current) {
-            return;
-          }
-
           if (errors) {
             setErrors(errors.slice());
             return;
           }
 
-          const modal = Modal.getInstance(ref.current);
-          modal?.hide();
+          setShow(false);
           navigate(
             `/tagged_artworks/${encodeURIComponent(
               response.updateTag?.tag?.name ?? "",
@@ -81,51 +68,40 @@ export const UpdateTagModal: React.FC<UpdateTagModalProps> = ({ tagKey }) => {
   );
 
   return (
-    <div
-      className="modal fade"
-      id="updateTagModal"
-      aria-hidden="true"
-      ref={ref}
-    >
-      <div className="modal-dialog">
-        <div className="modal-content">
-          <form onSubmit={handleUpdate}>
-            <div className="modal-header">
-              <h5 className="modal-title">タグの情報編集</h5>
-              <button
-                type="button"
-                className="btn-close"
-                aria-label="閉じる"
-                data-bs-dismiss="modal"
-              ></button>
-            </div>
-            <div className="modal-body">
-              {errors &&
-                errors.map((error, i) => (
-                  <div key={i} className="alert alert-danger" role="alert">
-                    {error.message}
-                  </div>
-                ))}
-              <label htmlFor="name" className="form-label">
-                タグ名 <span className="text-danger">(必須)</span>
-              </label>
-              <input
-                type="text"
-                id="name"
-                className="form-control"
-                required
-                value={name}
-                onChange={(e) => setName(e.target.value.trim())}
-              />
-            </div>
-            <div className="modal-footer">
-              <button type="submit" className="btn btn-primary form-control">
-                保存する
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </div>
+    <>
+      <Button variant="primary" onClick={() => setShow(true)}>
+        情報の編集
+      </Button>
+      <Modal show={show} onHide={handleHide}>
+        <form onSubmit={handleUpdate}>
+          <Modal.Header closeButton>
+            <Modal.Title>タグの情報編集</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            {errors &&
+              errors.map((error, i) => (
+                <Alert key={i} variant="danger">
+                  {error.message}
+                </Alert>
+              ))}
+            <Form.Label htmlFor="name">
+              タグ名 <span className="text-danger">(必須)</span>
+            </Form.Label>
+            <Form.Control
+              type="text"
+              id="name"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value.trim())}
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button type="submit" variant="primary" className="w-100">
+              保存する
+            </Button>
+          </Modal.Footer>
+        </form>
+      </Modal>
+    </>
   );
 };

--- a/front/src/components/TegakiDU/Sidebar.tsx
+++ b/front/src/components/TegakiDU/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useContext, useState } from "react";
+import { Button, Container } from "react-bootstrap";
 
 import { ArtworkInformationProvider } from "../../contexts/ArtworkInformationContext";
 import { DrawingContext } from "../../contexts/TegakiDU/DrawingContext";
@@ -62,7 +63,7 @@ export const Sidebar: React.FC = () => {
   }, [setIsPosting, toBlob]);
 
   return (
-    <div className="container h-100">
+    <Container className="h-100">
       <ArtworkInformationProvider initialTags={["tegaki_du"]}>
         <UploadArtworkProvider>
           <UploadArtworkModal blob={serializedBlob} />
@@ -111,42 +112,48 @@ export const Sidebar: React.FC = () => {
       </div>
       <div className="row">
         <div className="col">
-          <button
-            className="btn btn-secondary w-100"
+          <Button
+            variant="secondary"
+            className="w-100"
             disabled={!undoable}
             onClick={undo}
           >
             元に戻す
-          </button>
+          </Button>
         </div>
         <div className="col">
-          <button
-            className="btn btn-secondary w-100"
+          <Button
+            variant="secondary"
+            className="w-100"
             disabled={!redoable}
             onClick={redo}
           >
             やり直す
-          </button>
+          </Button>
         </div>
         <div className="my-2">
-          <button className="btn btn-danger w-100" onClick={handleDeleteAll}>
+          <Button variant="danger" className="w-100" onClick={handleDeleteAll}>
             全て消す
-          </button>
+          </Button>
         </div>
         <div className="d-flex justify-content-around">
           <div className="col-sm-8">
-            <button className="btn btn-success w-100" onClick={handleUpload}>
+            <Button variant="success" className="w-100" onClick={handleUpload}>
               アップロード
-            </button>
+            </Button>
           </div>
           <div className="col-sm-4">
-            <button className="btn btn-primary w-100" onClick={handleDownload}>
+            <Button
+              variant="primary"
+              className="w-100"
+              onClick={handleDownload}
+            >
               DL
-            </button>
+            </Button>
           </div>
         </div>
         {isSerializing && <div>シリアライズ中……</div>}
       </div>
-    </div>
+    </Container>
   );
 };

--- a/front/src/components/TegakiDU/UploadArtworkModal.tsx
+++ b/front/src/components/TegakiDU/UploadArtworkModal.tsx
@@ -1,6 +1,5 @@
-import { Modal } from "bootstrap";
-import React, { useContext, useRef } from "react";
-import { useEffect } from "react";
+import React, { useContext, useState, useEffect } from "react";
+import { Button, Modal, Spinner } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery } from "react-relay";
 
@@ -33,50 +32,19 @@ export const UploadArtworkModal: React.FC<Props> = ({ blob }) => {
     handleSubmit,
   } = useUploadArtworkContext();
   const { setIsPosting } = useContext(DrawingContext);
+  const [show, setShow] = useState(false);
 
   useEffect(() => {
     if (blob) {
       setFiles([blob]);
+      setShow(true);
     }
   }, [blob, setFiles]);
 
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-
-    const modal = new Modal(ref.current);
-    return () => {
-      modal.hide();
-    };
-  }, []);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) {
-      return;
-    }
-
-    const modal = Modal.getInstance(el);
-    if (!modal) {
-      return;
-    }
-
-    if (blob) {
-      modal.show();
-    }
-
-    const hideModal = () => {
-      setIsPosting(false);
-    };
-
-    el.addEventListener("hidden.bs.modal", hideModal);
-    return () => {
-      el.removeEventListener("hidden.bs.modal", hideModal);
-    };
-  }, [blob, setIsPosting]);
+  const handleHide = () => {
+    setShow(false);
+    setIsPosting(false);
+  };
 
   const { viewer } = useLazyLoadQuery<UploadArtworkModalQuery>(
     graphql`
@@ -96,122 +64,98 @@ export const UploadArtworkModal: React.FC<Props> = ({ blob }) => {
   const { ageRestriction } = useArtworkInformation();
 
   return (
-    <>
-      <div
-        className="modal fade"
-        id="updateArtworkModal"
-        aria-hidden="true"
-        ref={ref}
-      >
-        <div className="modal-dialog modal-lg">
-          <div className="modal-content">
-            <form onSubmit={handleSubmit}>
-              <div className="modal-header">
-                <h5 className="modal-title">画像のアップロード</h5>
-                <button
-                  type="button"
-                  className="btn-close"
-                  aria-label="閉じる"
-                  data-bs-dismiss="modal"
-                ></button>
-              </div>
-              <div className="modal-body">
-                <div className="mb-3">
-                  <TitleInput />
-                </div>
-                <div className="mb-3">
-                  <CaptionInput />
-                </div>
-                <div className="mb-3">
-                  <TagsInput />
-                </div>
-                <div className="mb-3">
-                  <AgeRestrictionInput />
-                </div>
-                <div className="mb-3">
-                  <label htmlFor="notify_slack">Slackに通知する</label>
-                  <input
-                    type="checkbox"
-                    id="notify_slack"
-                    checked={notifySlack}
-                    onChange={(e) => setNotifySlack(e.target.checked)}
-                  />
-                </div>
-                {
-                  <>
-                    <div className="mb-3">
-                      <label htmlFor="notify_twitter">
-                        Twitterにも投稿する
-                        (KMCのアカウントで公開されるので注意)
-                      </label>
-                      <input
-                        type="checkbox"
-                        id="notify_twitter"
-                        checked={ageRestriction === "SAFE" && notifyTwitter}
-                        disabled={ageRestriction !== "SAFE"}
-                        onChange={(e) => setNotifyTwitter(e.target.checked)}
-                      />
-                    </div>
-                    {ageRestriction === "SAFE" ? (
-                      notifyTwitter && (
-                        <div className="mb-3">
-                          Twitter投稿時のユーザー名
-                          <input
-                            type="text"
-                            id="twitter_name"
-                            value={twitterUserName}
-                            onChange={(e) => setTwitterUserName(e.target.value)}
-                          />
-                        </div>
-                      )
-                    ) : (
-                      <p className="mb-3 text-danger">
-                        年齢制限のある作品をTwitterに共有することはできません
-                      </p>
-                    )}
-                  </>
-                }
-                <div className="mb-3">
-                  <label htmlFor="show_thumbnail">
-                    サムネイルを表示する (Gyazoに自動的に投稿されます)
-                  </label>
-                  <input
-                    type="checkbox"
-                    id="show_thumbnail"
-                    disabled={!notifySlack}
-                    checked={showThumbnail}
-                    onChange={(e) => setShowThumbnail(e.target.checked)}
-                  />
-                </div>
-                <div className="mb-3">
-                  <SlackChannelInput />
-                </div>
-                <div className="modal-footer">
-                  <button
-                    type="submit"
-                    className="btn btn-primary form-control"
-                    disabled={isUploading}
-                  >
-                    {isUploading ? (
-                      <div className="d-flex align-items-center justify-content-center">
-                        <div>
-                          <span
-                            className="spinner-border text-light"
-                            role="status"
-                          ></span>
-                        </div>
-                        <div>アップロード中……</div>
-                      </div>
-                    ) : (
-                      "アップロードする"
-                    )}
-                  </button>
-                </div>
-              </div>
-            </form>
+    <Modal show={show} onHide={handleHide} size="lg">
+      <form onSubmit={handleSubmit}>
+        <Modal.Header closeButton>
+          <Modal.Title>画像のアップロード</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="mb-3">
+            <TitleInput />
           </div>
-        </div>
-      </div>
-    </>
+          <div className="mb-3">
+            <CaptionInput />
+          </div>
+          <div className="mb-3">
+            <TagsInput />
+          </div>
+          <div className="mb-3">
+            <AgeRestrictionInput />
+          </div>
+          <div className="mb-3">
+            <label htmlFor="notify_slack">Slackに通知する</label>
+            <input
+              type="checkbox"
+              id="notify_slack"
+              checked={notifySlack}
+              onChange={(e) => setNotifySlack(e.target.checked)}
+            />
+          </div>
+          <>
+            <div className="mb-3">
+              <label htmlFor="notify_twitter">
+                Twitterにも投稿する (KMCのアカウントで公開されるので注意)
+              </label>
+              <input
+                type="checkbox"
+                id="notify_twitter"
+                checked={ageRestriction === "SAFE" && notifyTwitter}
+                disabled={ageRestriction !== "SAFE"}
+                onChange={(e) => setNotifyTwitter(e.target.checked)}
+              />
+            </div>
+            {ageRestriction === "SAFE" ? (
+              notifyTwitter && (
+                <div className="mb-3">
+                  Twitter投稿時のユーザー名
+                  <input
+                    type="text"
+                    id="twitter_name"
+                    value={twitterUserName}
+                    onChange={(e) => setTwitterUserName(e.target.value)}
+                  />
+                </div>
+              )
+            ) : (
+              <p className="mb-3 text-danger">
+                年齢制限のある作品をTwitterに共有することはできません
+              </p>
+            )}
+          </>
+          <div className="mb-3">
+            <label htmlFor="show_thumbnail">
+              サムネイルを表示する (Gyazoに自動的に投稿されます)
+            </label>
+            <input
+              type="checkbox"
+              id="show_thumbnail"
+              disabled={!notifySlack}
+              checked={showThumbnail}
+              onChange={(e) => setShowThumbnail(e.target.checked)}
+            />
+          </div>
+          <div className="mb-3">
+            <SlackChannelInput />
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            type="submit"
+            variant="primary"
+            className="w-100"
+            disabled={isUploading}
+          >
+            {isUploading ? (
+              <div className="d-flex align-items-center justify-content-center">
+                <Spinner size="sm" className="me-2" />
+                アップロード中……
+              </div>
+            ) : (
+              "アップロードする"
+            )}
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
   );
 };

--- a/front/src/components/UserDetail/UpdateInfoForm.tsx
+++ b/front/src/components/UserDetail/UpdateInfoForm.tsx
@@ -1,5 +1,5 @@
-import { Modal } from "bootstrap";
-import React, { useState, useCallback, useEffect, useRef } from "react";
+import React, { useState, useCallback } from "react";
+import { Button, Form, Modal } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment, useRelayEnvironment } from "react-relay";
 
@@ -21,24 +21,17 @@ export const UpdateAccountModal: React.FC<Props> = ({ account: _account }) => {
     `,
     _account,
   );
+  const [show, setShow] = useState(false);
   const [name, setName] = useState(account.name || "");
-  const ref = useRef<HTMLDivElement>(null);
 
   const resetStates = useCallback(() => {
     // explicitly reset values
     setName(account.name || "");
   }, [account.name]);
 
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) {
-      return;
-    }
-
-    el.addEventListener("hidden.bs.modal", resetStates);
-    return () => {
-      el.removeEventListener("hidden.bs.modal", resetStates);
-    };
+  const handleHide = useCallback(() => {
+    setShow(false);
+    resetStates();
   }, [resetStates]);
 
   const handleUpdate = useCallback(
@@ -51,8 +44,7 @@ export const UpdateAccountModal: React.FC<Props> = ({ account: _account }) => {
           },
         },
         onCompleted: () => {
-          const modal = Modal.getInstance(ref.current!);
-          modal?.hide();
+          setShow(false);
         },
       });
     },
@@ -61,69 +53,46 @@ export const UpdateAccountModal: React.FC<Props> = ({ account: _account }) => {
 
   return (
     <>
-      <div
-        className="modal fade"
-        id="updateAccountModal"
-        aria-hidden="true"
-        ref={ref}
-      >
-        <div className="modal-dialog">
-          <div className="modal-content">
-            <form onSubmit={handleUpdate}>
-              <div className="modal-header">
-                <h5 className="modal-title">絵師情報の編集</h5>
-                <button
-                  type="button"
-                  className="btn-close"
-                  aria-label="閉じる"
-                  data-bs-dismiss="modal"
-                ></button>
-              </div>
-              <div className="modal-body">
-                <div className="mb-3">
-                  <label htmlFor="kmcid" className="form-label">
-                    KMC-ID
-                  </label>
-                  <input
-                    type="text"
-                    id="kmcid"
-                    className="form-control"
-                    value={account.kmcid}
-                    disabled
-                  />
-                </div>
-                <div className="mb-3">
-                  <label htmlFor="title" className="form-label">
-                    表示名 <span className="text-danger">(必須)</span>
-                  </label>
-                  <input
-                    type="text"
-                    id="title"
-                    className="form-control"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    required
-                  />
-                </div>
-              </div>
-              <div className="modal-footer">
-                <button type="submit" className="btn btn-primary form-control">
-                  保存する
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      </div>
       <div className="d-flex justify-content-center mb-2">
-        <button
-          className="btn btn-primary"
-          data-bs-toggle="modal"
-          data-bs-target="#updateAccountModal"
-        >
+        <Button variant="primary" onClick={() => setShow(true)}>
           情報の編集
-        </button>
+        </Button>
       </div>
+      <Modal show={show} onHide={handleHide}>
+        <form onSubmit={handleUpdate}>
+          <Modal.Header closeButton>
+            <Modal.Title>絵師情報の編集</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <div className="mb-3">
+              <Form.Label htmlFor="kmcid">KMC-ID</Form.Label>
+              <Form.Control
+                type="text"
+                id="kmcid"
+                value={account.kmcid}
+                disabled
+              />
+            </div>
+            <div className="mb-3">
+              <Form.Label htmlFor="title">
+                表示名 <span className="text-danger">(必須)</span>
+              </Form.Label>
+              <Form.Control
+                type="text"
+                id="title"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                required
+              />
+            </div>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button type="submit" variant="primary" className="w-100">
+              保存する
+            </Button>
+          </Modal.Footer>
+        </form>
+      </Modal>
     </>
   );
 };

--- a/front/src/hooks/useTooltip.ts
+++ b/front/src/hooks/useTooltip.ts
@@ -1,20 +1,2 @@
-import { Tooltip } from "bootstrap";
-import { useEffect, useRef } from "react";
-
-export const useTooltip = <TElement extends string | Element>() => {
-  const ref = useRef<TElement>(null);
-
-  useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
-
-    const tooltip = new Tooltip(ref.current);
-    return () => {
-      // ページ遷移したときにツールチップが消えるようにする
-      tooltip.hide();
-    };
-  });
-
-  return ref;
-};
+// このファイルは使用されていません。OverlayTrigger + Tooltip (react-bootstrap) を直接使用してください。
+export {};

--- a/front/src/mocks/db.ts
+++ b/front/src/mocks/db.ts
@@ -199,7 +199,10 @@ export function toPaginatedConnection<T>(
   const slice = nodes.slice(startIndex, startIndex + first);
   const hasNextPage = startIndex + first < nodes.length;
   return {
-    edges: slice.map((node, i) => ({ node, cursor: btoa(String(startIndex + i)) })),
+    edges: slice.map((node, i) => ({
+      node,
+      cursor: btoa(String(startIndex + i)),
+    })),
     pageInfo: {
       hasNextPage,
       hasPreviousPage: startIndex > 0,
@@ -226,7 +229,10 @@ export function toPaginatedConnectionBackward<T>(
   const startIndex = Math.max(0, endIndex - last);
   const slice = nodes.slice(startIndex, endIndex);
   return {
-    edges: slice.map((node, i) => ({ node, cursor: btoa(String(startIndex + i)) })),
+    edges: slice.map((node, i) => ({
+      node,
+      cursor: btoa(String(startIndex + i)),
+    })),
     pageInfo: {
       hasNextPage: endIndex < nodes.length,
       hasPreviousPage: startIndex > 0,

--- a/front/src/pages/ArtworkDetail.tsx
+++ b/front/src/pages/ArtworkDetail.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import React, { Fragment, useMemo } from "react";
+import { Card } from "react-bootstrap";
 import { Helmet } from "react-helmet";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery } from "react-relay";
@@ -154,8 +155,8 @@ const ArtworkDetail: React.FC = () => {
           {`${artwork.title} - ${artwork.account?.name}のイラスト - God Illust Uploader`}
         </title>
       </Helmet>
-      <div className="card">
-        <div className="card-header text-center">
+      <Card>
+        <Card.Header className="text-center">
           <h2>{artwork.title}</h2>
           <Caption caption={artwork.caption} />
           <p>
@@ -174,8 +175,8 @@ const ArtworkDetail: React.FC = () => {
               <UpdateArtworkModal artworkKey={artwork} />
             </ArtworkInformationProvider>
           )}
-        </div>
-        <div className="card-body">
+        </Card.Header>
+        <Card.Body>
           {((artwork.tags?.edges && artwork.tags.edges.length > 0) ||
             artwork.rating !== "safe") && (
             <div className="row">
@@ -222,8 +223,8 @@ const ArtworkDetail: React.FC = () => {
               <DeleteArtworkButton artworkId={artwork.id} />
             </div>
           )}
-        </div>
-        <div className="card-footer">
+        </Card.Body>
+        <Card.Footer>
           <nav aria-label="前後の作品">
             <ul
               className={clsx(
@@ -285,8 +286,8 @@ const ArtworkDetail: React.FC = () => {
               )}
             </ul>
           </nav>
-        </div>
-      </div>
+        </Card.Footer>
+      </Card>
     </div>
   );
 };

--- a/front/src/pages/Index.tsx
+++ b/front/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Badge, Card } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery } from "react-relay";
 
@@ -42,11 +43,11 @@ export const Index: React.FC = () => {
   return (
     <div>
       {safeArtworks && safeArtworks.edges ? (
-        <div className="card mb-5">
-          <div className="card-header">
+        <Card className="mb-5">
+          <Card.Header>
             <h2 className="text-center">最新{artworkCount}件の絵</h2>
-          </div>
-          <div className="card-body">
+          </Card.Header>
+          <Card.Body>
             <div className="row row-cols-1 row-cols-lg-4">
               {safeArtworks.edges.map((edge, i) => {
                 if (!edge) {
@@ -71,16 +72,16 @@ export const Index: React.FC = () => {
             >
               もっと見る
             </Link>
-          </div>
-        </div>
+          </Card.Body>
+        </Card>
       ) : (
-        <div className="card mb-5"></div> // fallback
+        <Card className="mb-5" /> // fallback
       )}
-      <div className="card">
-        <div className="card-header">
+      <Card>
+        <Card.Header>
           <h2 className="text-center">利用者達</h2>
-        </div>
-        <div className="card-body">
+        </Card.Header>
+        <Card.Body>
           <div className="row row-cols-2 row-cols-lg-4">
             {activeAccounts?.edges.map((edge, i) => {
               if (!(edge && edge.node)) {
@@ -95,16 +96,16 @@ export const Index: React.FC = () => {
                     className="btn btn-outline-secondary text-center w-100 d-flex justify-content-between"
                   >
                     {node.name}
-                    <span className="badge rounded-pill bg-secondary">
+                    <Badge bg="secondary" pill>
                       {node.artworksCount}
-                    </span>
+                    </Badge>
                   </Link>
                 </div>
               );
             })}
           </div>
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
     </div>
   );
 };

--- a/front/src/pages/NotFound.tsx
+++ b/front/src/pages/NotFound.tsx
@@ -1,13 +1,14 @@
 import React from "react";
+import { Alert } from "react-bootstrap";
 import { useLocation } from "react-router";
 
 const NotFound: React.FC = () => {
   const location = useLocation();
   return (
-    <div className="alert alert-warning">
-      <h4 className="alert-heading">ページがみつかりません</h4>
+    <Alert variant="warning">
+      <Alert.Heading>ページがみつかりません</Alert.Heading>
       <pre>{location.pathname}</pre>
-    </div>
+    </Alert>
   );
 };
 

--- a/front/src/pages/RecentArtworks.tsx
+++ b/front/src/pages/RecentArtworks.tsx
@@ -1,10 +1,11 @@
 import React, { ChangeEventHandler, useCallback } from "react";
-import { InfiniteScroll } from "../components/InfiniteScroll";
+import { Card, Form, Spinner } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery, usePaginationFragment } from "react-relay";
 import { useLocation, useNavigate } from "react-router";
 
 import { ArtworkListItem } from "../components/ArtworkListItem";
+import { InfiniteScroll } from "../components/InfiniteScroll";
 import { RecentArtworkListPaginationQuery } from "./__generated__/RecentArtworkListPaginationQuery.graphql";
 import type {
   ArtworkRatingEnum,
@@ -78,9 +79,9 @@ const ArtworkList: React.FC<{
       hasMore={hasNext && !isLoadingNext}
       loader={
         <div key={0} className="d-flex justify-content-center">
-          <div className="spinner-border text-light" role="status">
+          <Spinner animation="border" variant="light" role="status">
             <span className="visually-hidden">Uploading...</span>
-          </div>
+          </Spinner>
         </div>
       }
     >
@@ -122,14 +123,13 @@ export const RecentArtworks: React.FC = () => {
 
   return (
     <div>
-      <div className="card">
-        <div className="card-header">
+      <Card>
+        <Card.Header>
           <h2 className="text-center flex-fill">最新の絵</h2>
           <div className="d-flex justify-content-end">
             <div>
-              <select
+              <Form.Select
                 id="rating-select"
-                className="form-select"
                 value={selectedRating}
                 onChange={handleChangeRating}
               >
@@ -137,14 +137,14 @@ export const RecentArtworks: React.FC = () => {
                 <option value="r_18">R-18</option>
                 <option value="r_18g">R-18G</option>
                 <option value="all">全て (NSFW含む)</option>
-              </select>
+              </Form.Select>
             </div>
           </div>
-        </div>
-        <div className="card-body">
+        </Card.Header>
+        <Card.Body>
           <ArtworkList artworks={artworks} />
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
     </div>
   );
 };

--- a/front/src/pages/TaggedArtworks.tsx
+++ b/front/src/pages/TaggedArtworks.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Card } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery } from "react-relay";
 import { Navigate, useParams } from "react-router";
@@ -50,23 +51,16 @@ const Inner: React.FC<{ tag: string }> = ({ tag }) => {
 
   return (
     <div>
-      <div className="card">
-        <div className="card-header">
+      <Card>
+        <Card.Header>
           <h2 className="text-center">タグ&quot;{tag}&quot;の絵たち</h2>
           {!tagByName.editFreezed && (
             <div className="d-flex justify-content-center mb-2">
               <UpdateTagModal tagKey={tagByName} />
-              <button
-                className="btn btn-primary"
-                data-bs-toggle="modal"
-                data-bs-target="#updateTagModal"
-              >
-                情報の編集
-              </button>
             </div>
           )}
-        </div>
-        <div className="card-body">
+        </Card.Header>
+        <Card.Body>
           <div className="row row-cols-1 row-cols-lg-4">
             {taggedArtworks?.edges.map((edge, i) => {
               if (!(edge && edge.node)) {
@@ -80,8 +74,8 @@ const Inner: React.FC<{ tag: string }> = ({ tag }) => {
               );
             })}
           </div>
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
     </div>
   );
 };

--- a/front/src/pages/Tags.tsx
+++ b/front/src/pages/Tags.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Badge, Card } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery } from "react-relay";
 
@@ -25,11 +26,11 @@ export const Tags: React.FC = () => {
 
   return (
     <div>
-      <div className="card">
-        <div className="card-header">
+      <Card>
+        <Card.Header>
           <h2 className="text-center">タグまとめ</h2>
-        </div>
-        <div className="card-body">
+        </Card.Header>
+        <Card.Body>
           <div className="d-flex flex-wrap justify-content-between">
             {allTags?.edges.map((edge, i) => {
               if (!(edge && edge.node)) {
@@ -44,16 +45,16 @@ export const Tags: React.FC = () => {
                     className="btn btn-outline-secondary text-center w-100 d-flex justify-content-between flex-fill"
                   >
                     <div className="me-auto">#{node.name}</div>
-                    <div className="badge rounded-pill bg-secondary ms-1">
+                    <Badge bg="secondary" pill className="ms-1">
                       {node.artworksCount}
-                    </div>
+                    </Badge>
                   </Link>
                 </div>
               );
             })}
           </div>
-        </div>
-      </div>
+        </Card.Body>
+      </Card>
     </div>
   );
 };

--- a/front/src/pages/UploadArtwork.tsx
+++ b/front/src/pages/UploadArtwork.tsx
@@ -16,6 +16,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import React, { useCallback, useEffect, useMemo } from "react";
+import { Alert, Button, Card, Spinner } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery } from "react-relay";
 
@@ -127,8 +128,8 @@ const UploadArtworkForm = () => {
   const { ageRestriction } = useArtworkInformation();
 
   return (
-    <div className="card">
-      <div className="card-header">画像のアップロード</div>
+    <Card>
+      <Card.Header>画像のアップロード</Card.Header>
       <div className="panel-body px-4 py-4">
         <form onSubmit={handleSubmit}>
           <div className="mb-3">
@@ -150,9 +151,9 @@ const UploadArtworkForm = () => {
             />
             <FilesizeBar filesize={totalFilesize} maxFilesize={MAX_FILESIZE} />
             {filesizeLimitExceeded && (
-              <div className="alert alert-danger mt-3" role="alert">
+              <Alert variant="danger" className="mt-3">
                 アップロードするファイルのサイズが大きすぎます
-              </div>
+              </Alert>
             )}
             <div className="d-flex mt-2">
               {images.length > 0 && (
@@ -263,37 +264,33 @@ const UploadArtworkForm = () => {
             <SlackChannelInput />
           </div>
           <div>
-            <button
+            <Button
               type="submit"
-              className="btn btn-primary form-control"
+              variant="primary"
+              className="w-100"
               disabled={
                 files.length === 0 || isUploading || filesizeLimitExceeded
               }
             >
               {isUploading ? (
                 <div className="d-flex align-items-center justify-content-center">
-                  <div>
-                    <span
-                      className="spinner-border text-light"
-                      role="status"
-                    ></span>
-                  </div>
-                  <div>アップロード中……</div>
+                  <Spinner size="sm" className="me-2" />
+                  アップロード中……
                 </div>
               ) : (
                 "アップロードする"
               )}
-            </button>
+            </Button>
           </div>
           {uploadErrors &&
             uploadErrors.map((error, i) => (
-              <div key={i} className="alert alert-danger mt-3" role="alert">
+              <Alert key={i} variant="danger" className="mt-3">
                 {error.message}
-              </div>
+              </Alert>
             ))}
         </form>
       </div>
-    </div>
+    </Card>
   );
 };
 

--- a/front/src/pages/UserDetail.tsx
+++ b/front/src/pages/UserDetail.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback } from "react";
-import { InfiniteScroll } from "../components/InfiniteScroll";
+import { Card, Spinner } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery, usePaginationFragment } from "react-relay";
 import { useParams } from "react-router";
 
 import { ArtworkListItem } from "../components/ArtworkListItem";
+import { InfiniteScroll } from "../components/InfiniteScroll";
 import { UpdateAccountModal } from "../components/UserDetail/UpdateInfoForm";
 import { ArtworkListPaginationQuery } from "./__generated__/ArtworkListPaginationQuery.graphql";
 import { UserDetailQuery } from "./__generated__/UserDetailQuery.graphql";
@@ -35,13 +36,13 @@ export const UserDetail: React.FC = () => {
 
   return (
     <div>
-      <div className="card">
-        <div className="card-header">
+      <Card>
+        <Card.Header>
           <h2 className="text-center mb-4">{user.name}の作品置場</h2>
           {user.isYou && <UpdateAccountModal account={user} />}
-        </div>
+        </Card.Header>
         <ArtworkList user={user} />
-      </div>
+      </Card>
     </div>
   );
 };
@@ -91,15 +92,15 @@ const ArtworkList: React.FC<{ user: UserDetail_artworks$key }> = ({ user }) => {
   const reversedEdges = edges.slice().reverse();
 
   return (
-    <div className="card-body">
+    <Card.Body>
       <InfiniteScroll
         loadMore={handleLoadArtworks}
         hasMore={hasPrevious && !isLoadingPrevious}
         loader={
           <div key={0} className="d-flex justify-content-center">
-            <div className="spinner-border text-light" role="status">
+            <Spinner animation="border" variant="light" role="status">
               <span className="visually-hidden">Uploading...</span>
-            </div>
+            </Spinner>
           </div>
         }
       >
@@ -117,6 +118,6 @@ const ArtworkList: React.FC<{ user: UserDetail_artworks$key }> = ({ user }) => {
           })}
         </div>
       </InfiniteScroll>
-    </div>
+    </Card.Body>
   );
 };


### PR DESCRIPTION
Closes #3

## 概要

Bootstrap 5 を直接使用していた実装を react-bootstrap を通じた実装に移行します。

### 背景

これまでは Bootstrap の CSS クラスを `className` に直書きするだけでなく、Bootstrap の JS コンポーネント（`Modal`, `Carousel`, `Collapse`, `Tooltip`）を直接 import して命令的に操作していました。この方法は React のプログラミングモデル（props による宣言的な制御）と相性が悪く、DOM イベントリスナーを手動で管理する必要があるなど、コードが複雑になっていました。

## 主な変更内容

### Bootstrap JS の命令的操作を廃止

| 変更前 | 変更後 |
|--------|--------|
| `Modal.getInstance(ref).hide()` | `setShow(false)` でステート制御 |
| `hidden.bs.modal` イベントリスナー | `onHide` コールバック |
| `data-bs-toggle="modal"` 属性 | `onClick={() => setShow(true)}` |
| `new Collapse(ref)` / `.hide()` | `<Navbar expanded={expanded} onToggle={setExpanded}>` |
| `new Carousel(ref)` / `.next()` / `.to(i)` | `<Carousel activeIndex={index} onSelect={setIndex}>` |
| `new Tooltip(ref)` | `<OverlayTrigger>` + `<Tooltip>` |

### 影響ファイル

**Bootstrap JS 直接使用を廃止（最重要）:**
- `components/TaggedArtworks/UpdateTagModal.tsx` — Modal
- `components/ArtworkDetail/UpdateArtworkForm.tsx` — Modal
- `components/UserDetail/UpdateInfoForm.tsx` — Modal
- `components/TegakiDU/UploadArtworkModal.tsx` — Modal
- `components/Header.tsx` — Collapse → Navbar
- `components/ArtworkDetail/IllustCarousel.tsx` — Carousel
- `hooks/useTooltip.ts` — 廃止、OverlayTrigger に置き換え
- `components/ArtworkDetail/ArtworkLikeList.tsx` — OverlayTrigger + Tooltip

**UI コンポーネントも react-bootstrap に移行:**
- `Card`, `Alert`, `Button`, `Badge`
- `Form.Control`, `Form.Label`, `Form.Select`, `Form.Check`
- `ProgressBar`, `ListGroup`, `Spinner`
- `Container`, `Navbar`

### 変更していない点

- `bootstrap/dist/css/bootstrap.min.css` の import は維持（react-bootstrap は CSS を含まない）
- `bootstrap-icons` の CSS と `bi-*` クラスはそのまま使用
- `d-flex`, `mb-*`, `row`, `col-*` 等のユーティリティクラスは `className` としてそのまま使用

---
_Generated by [Claude Code](https://claude.ai/code/session_01CybMjU5DeKbrh35JYVhuGH)_