### PR TITLE
モーダルコンポーネントを ModalForm として共通化する

### DIFF
--- a/front/src/components/ArtworkDetail/UpdateArtworkForm.tsx
+++ b/front/src/components/ArtworkDetail/UpdateArtworkForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import { Button, Modal } from "react-bootstrap";
+import { Button } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment, useRelayEnvironment } from "react-relay";
 
@@ -7,6 +7,7 @@ import { AgeRestrictionInput } from "../../components/ArtworkInfoForm/AgeRestric
 import { CaptionInput } from "../../components/ArtworkInfoForm/CaptionInput";
 import { TagsInput } from "../../components/ArtworkInfoForm/TagsInput";
 import { TitleInput } from "../../components/ArtworkInfoForm/TitleInput";
+import { ModalForm } from "../../components/ModalForm";
 import {
   ageRestirctionToRating,
   ratingToAgeRestriction,
@@ -111,32 +112,26 @@ export const UpdateArtworkModal: React.FC<Props> = ({ artworkKey }) => {
       <Button variant="primary" onClick={() => setShow(true)}>
         情報の編集
       </Button>
-      <Modal show={show} onHide={handleHide} size="xl">
-        <form onSubmit={handleUpdate}>
-          <Modal.Header closeButton>
-            <Modal.Title>神絵の情報編集</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <div className="mb-3">
-              <TitleInput />
-            </div>
-            <div className="mb-3">
-              <CaptionInput />
-            </div>
-            <div className="mb-3">
-              <TagsInput />
-            </div>
-            <div className="mb-3">
-              <AgeRestrictionInput />
-            </div>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button type="submit" variant="primary" className="w-100">
-              保存する
-            </Button>
-          </Modal.Footer>
-        </form>
-      </Modal>
+      <ModalForm
+        show={show}
+        onHide={handleHide}
+        onSubmit={handleUpdate}
+        title="神絵の情報編集"
+        size="xl"
+      >
+        <div className="mb-3">
+          <TitleInput />
+        </div>
+        <div className="mb-3">
+          <CaptionInput />
+        </div>
+        <div className="mb-3">
+          <TagsInput />
+        </div>
+        <div className="mb-3">
+          <AgeRestrictionInput />
+        </div>
+      </ModalForm>
     </>
   );
 };

--- a/front/src/components/ModalForm.tsx
+++ b/front/src/components/ModalForm.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Button, Modal, Spinner } from "react-bootstrap";
+
+interface ModalFormProps {
+  show: boolean;
+  onHide: () => void;
+  onSubmit: React.FormEventHandler;
+  title: string;
+  submitLabel?: string;
+  submittingLabel?: string;
+  size?: "sm" | "lg" | "xl";
+  isSubmitting?: boolean;
+  children: React.ReactNode;
+}
+
+export const ModalForm: React.FC<ModalFormProps> = ({
+  show,
+  onHide,
+  onSubmit,
+  title,
+  submitLabel = "保存する",
+  submittingLabel,
+  size,
+  isSubmitting = false,
+  children,
+}) => {
+  const activeLabel = submittingLabel ?? submitLabel;
+
+  return (
+    <Modal show={show} onHide={onHide} size={size}>
+      <form onSubmit={onSubmit}>
+        <Modal.Header closeButton>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{children}</Modal.Body>
+        <Modal.Footer>
+          <Button
+            type="submit"
+            variant="primary"
+            className="w-100"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <div className="d-flex align-items-center justify-content-center">
+                <Spinner size="sm" className="me-2" />
+                {activeLabel}
+              </div>
+            ) : (
+              submitLabel
+            )}
+          </Button>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+};

--- a/front/src/components/TaggedArtworks/UpdateTagModal.tsx
+++ b/front/src/components/TaggedArtworks/UpdateTagModal.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useState } from "react";
-import { Alert, Button, Form, Modal } from "react-bootstrap";
+import { Alert, Button, Form } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment, useRelayEnvironment } from "react-relay";
 import { useNavigate } from "react-router";
 import { PayloadError } from "relay-runtime";
 
+import { ModalForm } from "../../components/ModalForm";
 import { commitUpdateTagMutation } from "../../mutation/UpdateTag";
 import { UpdateTagModal_tag$key } from "./__generated__/UpdateTagModal_tag.graphql";
 
@@ -72,36 +73,29 @@ export const UpdateTagModal: React.FC<UpdateTagModalProps> = ({ tagKey }) => {
       <Button variant="primary" onClick={() => setShow(true)}>
         情報の編集
       </Button>
-      <Modal show={show} onHide={handleHide}>
-        <form onSubmit={handleUpdate}>
-          <Modal.Header closeButton>
-            <Modal.Title>タグの情報編集</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            {errors &&
-              errors.map((error, i) => (
-                <Alert key={i} variant="danger">
-                  {error.message}
-                </Alert>
-              ))}
-            <Form.Label htmlFor="name">
-              タグ名 <span className="text-danger">(必須)</span>
-            </Form.Label>
-            <Form.Control
-              type="text"
-              id="name"
-              required
-              value={name}
-              onChange={(e) => setName(e.target.value.trim())}
-            />
-          </Modal.Body>
-          <Modal.Footer>
-            <Button type="submit" variant="primary" className="w-100">
-              保存する
-            </Button>
-          </Modal.Footer>
-        </form>
-      </Modal>
+      <ModalForm
+        show={show}
+        onHide={handleHide}
+        onSubmit={handleUpdate}
+        title="タグの情報編集"
+      >
+        {errors &&
+          errors.map((error, i) => (
+            <Alert key={i} variant="danger">
+              {error.message}
+            </Alert>
+          ))}
+        <Form.Label htmlFor="name">
+          タグ名 <span className="text-danger">(必須)</span>
+        </Form.Label>
+        <Form.Control
+          type="text"
+          id="name"
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value.trim())}
+        />
+      </ModalForm>
     </>
   );
 };

--- a/front/src/components/TegakiDU/UploadArtworkModal.tsx
+++ b/front/src/components/TegakiDU/UploadArtworkModal.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState, useEffect } from "react";
-import { Button, Modal, Spinner } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useLazyLoadQuery } from "react-relay";
 
@@ -11,6 +10,7 @@ import { CaptionInput } from "../ArtworkInfoForm/CaptionInput";
 import { SlackChannelInput } from "../ArtworkInfoForm/SlackChannelInput";
 import { TagsInput } from "../ArtworkInfoForm/TagsInput";
 import { TitleInput } from "../ArtworkInfoForm/TitleInput";
+import { ModalForm } from "../ModalForm";
 import { UploadArtworkModalQuery } from "./__generated__/UploadArtworkModalQuery.graphql";
 
 interface Props {
@@ -64,98 +64,83 @@ export const UploadArtworkModal: React.FC<Props> = ({ blob }) => {
   const { ageRestriction } = useArtworkInformation();
 
   return (
-    <Modal show={show} onHide={handleHide} size="lg">
-      <form onSubmit={handleSubmit}>
-        <Modal.Header closeButton>
-          <Modal.Title>画像のアップロード</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <div className="mb-3">
-            <TitleInput />
-          </div>
-          <div className="mb-3">
-            <CaptionInput />
-          </div>
-          <div className="mb-3">
-            <TagsInput />
-          </div>
-          <div className="mb-3">
-            <AgeRestrictionInput />
-          </div>
-          <div className="mb-3">
-            <label htmlFor="notify_slack">Slackに通知する</label>
-            <input
-              type="checkbox"
-              id="notify_slack"
-              checked={notifySlack}
-              onChange={(e) => setNotifySlack(e.target.checked)}
-            />
-          </div>
-          <>
+    <ModalForm
+      show={show}
+      onHide={handleHide}
+      onSubmit={handleSubmit}
+      title="画像のアップロード"
+      size="lg"
+      isSubmitting={isUploading}
+      submitLabel="アップロードする"
+      submittingLabel="アップロード中……"
+    >
+      <div className="mb-3">
+        <TitleInput />
+      </div>
+      <div className="mb-3">
+        <CaptionInput />
+      </div>
+      <div className="mb-3">
+        <TagsInput />
+      </div>
+      <div className="mb-3">
+        <AgeRestrictionInput />
+      </div>
+      <div className="mb-3">
+        <label htmlFor="notify_slack">Slackに通知する</label>
+        <input
+          type="checkbox"
+          id="notify_slack"
+          checked={notifySlack}
+          onChange={(e) => setNotifySlack(e.target.checked)}
+        />
+      </div>
+      <>
+        <div className="mb-3">
+          <label htmlFor="notify_twitter">
+            Twitterにも投稿する (KMCのアカウントで公開されるので注意)
+          </label>
+          <input
+            type="checkbox"
+            id="notify_twitter"
+            checked={ageRestriction === "SAFE" && notifyTwitter}
+            disabled={ageRestriction !== "SAFE"}
+            onChange={(e) => setNotifyTwitter(e.target.checked)}
+          />
+        </div>
+        {ageRestriction === "SAFE" ? (
+          notifyTwitter && (
             <div className="mb-3">
-              <label htmlFor="notify_twitter">
-                Twitterにも投稿する (KMCのアカウントで公開されるので注意)
-              </label>
+              Twitter投稿時のユーザー名
               <input
-                type="checkbox"
-                id="notify_twitter"
-                checked={ageRestriction === "SAFE" && notifyTwitter}
-                disabled={ageRestriction !== "SAFE"}
-                onChange={(e) => setNotifyTwitter(e.target.checked)}
+                type="text"
+                id="twitter_name"
+                value={twitterUserName}
+                onChange={(e) => setTwitterUserName(e.target.value)}
               />
             </div>
-            {ageRestriction === "SAFE" ? (
-              notifyTwitter && (
-                <div className="mb-3">
-                  Twitter投稿時のユーザー名
-                  <input
-                    type="text"
-                    id="twitter_name"
-                    value={twitterUserName}
-                    onChange={(e) => setTwitterUserName(e.target.value)}
-                  />
-                </div>
-              )
-            ) : (
-              <p className="mb-3 text-danger">
-                年齢制限のある作品をTwitterに共有することはできません
-              </p>
-            )}
-          </>
-          <div className="mb-3">
-            <label htmlFor="show_thumbnail">
-              サムネイルを表示する (Gyazoに自動的に投稿されます)
-            </label>
-            <input
-              type="checkbox"
-              id="show_thumbnail"
-              disabled={!notifySlack}
-              checked={showThumbnail}
-              onChange={(e) => setShowThumbnail(e.target.checked)}
-            />
-          </div>
-          <div className="mb-3">
-            <SlackChannelInput />
-          </div>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button
-            type="submit"
-            variant="primary"
-            className="w-100"
-            disabled={isUploading}
-          >
-            {isUploading ? (
-              <div className="d-flex align-items-center justify-content-center">
-                <Spinner size="sm" className="me-2" />
-                アップロード中……
-              </div>
-            ) : (
-              "アップロードする"
-            )}
-          </Button>
-        </Modal.Footer>
-      </form>
-    </Modal>
+          )
+        ) : (
+          <p className="mb-3 text-danger">
+            年齢制限のある作品をTwitterに共有することはできません
+          </p>
+        )}
+      </>
+      <div className="mb-3">
+        <label htmlFor="show_thumbnail">
+          サムネイルを表示する (Gyazoに自動的に投稿されます)
+        </label>
+        <input
+          type="checkbox"
+          id="show_thumbnail"
+          disabled={!notifySlack}
+          checked={showThumbnail}
+          onChange={(e) => setShowThumbnail(e.target.checked)}
+        />
+      </div>
+      <div className="mb-3">
+        <SlackChannelInput />
+      </div>
+    </ModalForm>
   );
 };

--- a/front/src/components/UserDetail/UpdateInfoForm.tsx
+++ b/front/src/components/UserDetail/UpdateInfoForm.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useCallback } from "react";
-import { Button, Form, Modal } from "react-bootstrap";
+import { Button, Form } from "react-bootstrap";
 import { graphql } from "react-relay";
 import { useFragment, useRelayEnvironment } from "react-relay";
 
+import { ModalForm } from "../../components/ModalForm";
 import { commitUpdateAccountMutation } from "../../mutation/UpdateAccount";
 import { UpdateInfoForm_account$key } from "./__generated__/UpdateInfoForm_account.graphql";
 
@@ -58,41 +59,34 @@ export const UpdateAccountModal: React.FC<Props> = ({ account: _account }) => {
           情報の編集
         </Button>
       </div>
-      <Modal show={show} onHide={handleHide}>
-        <form onSubmit={handleUpdate}>
-          <Modal.Header closeButton>
-            <Modal.Title>絵師情報の編集</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <div className="mb-3">
-              <Form.Label htmlFor="kmcid">KMC-ID</Form.Label>
-              <Form.Control
-                type="text"
-                id="kmcid"
-                value={account.kmcid}
-                disabled
-              />
-            </div>
-            <div className="mb-3">
-              <Form.Label htmlFor="title">
-                表示名 <span className="text-danger">(必須)</span>
-              </Form.Label>
-              <Form.Control
-                type="text"
-                id="title"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                required
-              />
-            </div>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button type="submit" variant="primary" className="w-100">
-              保存する
-            </Button>
-          </Modal.Footer>
-        </form>
-      </Modal>
+      <ModalForm
+        show={show}
+        onHide={handleHide}
+        onSubmit={handleUpdate}
+        title="絵師情報の編集"
+      >
+        <div className="mb-3">
+          <Form.Label htmlFor="kmcid">KMC-ID</Form.Label>
+          <Form.Control
+            type="text"
+            id="kmcid"
+            value={account.kmcid}
+            disabled
+          />
+        </div>
+        <div className="mb-3">
+          <Form.Label htmlFor="title">
+            表示名 <span className="text-danger">(必須)</span>
+          </Form.Label>
+          <Form.Control
+            type="text"
+            id="title"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+      </ModalForm>
     </>
   );
 };


### PR DESCRIPTION
## 概要

Issue #2 で指摘されていた、モーダルコンポーネントのコピペ問題を解消します。

4つのモーダルで繰り返されていた以下の構造を共通コンポーネント `ModalForm` に抽出しました。

```tsx
<Modal show={show} onHide={handleHide} size="...">
  <form onSubmit={handleXxx}>
    <Modal.Header closeButton>
      <Modal.Title>タイトル</Modal.Title>
    </Modal.Header>
    <Modal.Body>{/* 内容 */}</Modal.Body>
    <Modal.Footer>
      <Button type="submit" variant="primary" className="w-100">
        保存する
      </Button>
    </Modal.Footer>
  </form>
</Modal>
```

## 変更内容

### 新規作成
- `front/src/components/ModalForm.tsx` — 共通モーダルフォームコンポーネント

### 修正
以下の4コンポーネントで `Modal` の直接利用を `ModalForm` に置き換えました。
- `front/src/components/ArtworkDetail/UpdateArtworkForm.tsx`
- `front/src/components/TaggedArtworks/UpdateTagModal.tsx`
- `front/src/components/TegakiDU/UploadArtworkModal.tsx`
- `front/src/components/UserDetail/UpdateInfoForm.tsx`

## `ModalForm` の props

| prop | 型 | デフォルト | 説明 |
|---|---|---|---|
| `show` | `boolean` | 必須 | モーダルの表示状態 |
| `onHide` | `() => void` | 必須 | 閉じるときのコールバック |
| `onSubmit` | `React.FormEventHandler` | 必須 | フォーム送信ハンドラ |
| `title` | `string` | 必須 | モーダルのタイトル |
| `submitLabel` | `string` | `"保存する"` | 送信ボタンのラベル |
| `submittingLabel` | `string` | `submitLabel` と同じ | 処理中の送信ボタンのラベル |
| `size` | `"sm" \| "lg" \| "xl"` | なし | モーダルのサイズ |
| `isSubmitting` | `boolean` | `false` | 処理中フラグ（ボタン無効化＋Spinner表示） |
| `children` | `ReactNode` | 必須 | モーダル本文 |

## テスト方法

- TypeScript コンパイルエラーがないことを `tsc --noEmit` で確認済み
- 各ページで対象モーダルの開閉・送信が正常に動作することを確認

Closes #2

https://claude.ai/code/session_016ooBfm8hA2gzxrUwua5DSc

---
_Generated by [Claude Code](https://claude.ai/code/session_016ooBfm8hA2gzxrUwua5DSc)_