### PR TITLE
フロントエンドのビルド成果物をダウンロード・デプロイするスクリプトを追加

### DIFF
--- a/front/scripts/download-artifacts.sh
+++ b/front/scripts/download-artifacts.sh
@@ -53,9 +53,32 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 api_get "$ARTIFACT_URL" -L -o "$TMPDIR/artifact.zip"
 
-echo "Extracting to $DIST_DIR..."
-rm -rf "$DIST_DIR"
-mkdir -p "$DIST_DIR"
-unzip -q "$TMPDIR/artifact.zip" -d "$DIST_DIR"
+DIST_PARENT="$(dirname "$DIST_DIR")"
+DIST_NAME="$(basename "$DIST_DIR")"
+NEW_DIST="$DIST_PARENT/${DIST_NAME}.new"
 
-echo "Done. Artifact extracted to $DIST_DIR"
+echo "Extracting to $NEW_DIST..."
+rm -rf "$NEW_DIST"
+mkdir -p "$NEW_DIST"
+unzip -q "$TMPDIR/artifact.zip" -d "$NEW_DIST"
+
+# Record the current symlink target (if any) so we can clean it up after the swap
+OLD_LINK_TARGET=""
+if [[ -L "$DIST_DIR" ]]; then
+  OLD_LINK_TARGET="$(readlink "$DIST_DIR")"
+  [[ "$OLD_LINK_TARGET" != /* ]] && OLD_LINK_TARGET="$DIST_PARENT/$OLD_LINK_TARGET"
+elif [[ -d "$DIST_DIR" ]]; then
+  # First run: dist is a real directory; move it aside before swapping
+  mv "$DIST_DIR" "$DIST_PARENT/${DIST_NAME}.old"
+  OLD_LINK_TARGET="$DIST_PARENT/${DIST_NAME}.old"
+fi
+
+# Atomically replace the symlink via rename(2): ln creates a temp symlink,
+# mv -T renames it over dist in a single syscall so dist is never absent
+ln -sfn "${DIST_NAME}.new" "$DIST_PARENT/${DIST_NAME}.tmp"
+mv -T "$DIST_PARENT/${DIST_NAME}.tmp" "$DIST_DIR"
+
+# Clean up the previous content now that the swap is complete
+[[ -n "$OLD_LINK_TARGET" ]] && rm -rf "$OLD_LINK_TARGET"
+
+echo "Done. Artifact deployed to $DIST_DIR"

--- a/front/scripts/download-artifacts.sh
+++ b/front/scripts/download-artifacts.sh
@@ -32,7 +32,7 @@ if [[ $# -ge 1 ]]; then
   echo "Using specified run ID: $RUN_ID"
 else
   echo "Fetching latest successful run of $WORKFLOW_FILE..."
-  RUN_ID=$(api_get "$API_BASE/repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?status=success&per_page=1" \
+  RUN_ID=$(api_get "$API_BASE/repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?status=success&branch=main&per_page=1" \
     | jq -r 'if (.workflow_runs | length) == 0 then error("No successful runs found") else .workflow_runs[0].id end')
   echo "Latest successful run ID: $RUN_ID"
 fi

--- a/front/scripts/download-artifacts.sh
+++ b/front/scripts/download-artifacts.sh
@@ -33,21 +33,19 @@ if [[ $# -ge 1 ]]; then
 else
   echo "Fetching latest successful run of $WORKFLOW_FILE..."
   RUN_ID=$(api_get "$API_BASE/repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?status=success&per_page=1" \
-    | python3 -c "import sys,json; runs=json.load(sys.stdin)['workflow_runs']; print(runs[0]['id']) if runs else (print('No successful runs found', file=sys.stderr) or exit(1))")
+    | jq -r 'if (.workflow_runs | length) == 0 then error("No successful runs found") else .workflow_runs[0].id end')
   echo "Latest successful run ID: $RUN_ID"
 fi
 
 echo "Fetching artifact list for run $RUN_ID..."
 ARTIFACT_URL=$(api_get "$API_BASE/repos/$REPO/actions/runs/$RUN_ID/artifacts" \
-  | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-artifacts = [a for a in data['artifacts'] if a['name'] == '$ARTIFACT_NAME']
-if not artifacts:
-    print('Artifact \"$ARTIFACT_NAME\" not found in run $RUN_ID', file=sys.stderr)
-    exit(1)
-print(artifacts[0]['archive_download_url'])
-")
+  | jq -r --arg name "$ARTIFACT_NAME" \
+      '.artifacts[] | select(.name == $name) | .archive_download_url' \
+  | head -1)
+if [[ -z "$ARTIFACT_URL" ]]; then
+  echo "Error: Artifact \"$ARTIFACT_NAME\" not found in run $RUN_ID" >&2
+  exit 1
+fi
 
 echo "Downloading artifact: $ARTIFACT_NAME"
 TMPDIR=$(mktemp -d)

--- a/front/scripts/download-artifacts.sh
+++ b/front/scripts/download-artifacts.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="kmc-jp/GodUploader-graphql"
+WORKFLOW_FILE="front.yml"
+ARTIFACT_NAME="build-artifacts"
+DIST_DIR="$(cd "$(dirname "$0")/../.." && pwd)/front/dist"
+TOKEN_FILE="$HOME/.secrets/goduploader-graphql-deploy"
+API_BASE="https://api.github.com"
+
+if [[ ! -f "$TOKEN_FILE" ]]; then
+  echo "Error: Token file not found: $TOKEN_FILE" >&2
+  exit 1
+fi
+
+# Read token without exposing it in logs or process list
+GITHUB_TOKEN=$(cat "$TOKEN_FILE")
+
+api_get() {
+  local url="$1"
+  shift
+  curl -fsSL \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$@" \
+    "$url"
+}
+
+if [[ $# -ge 1 ]]; then
+  RUN_ID="$1"
+  echo "Using specified run ID: $RUN_ID"
+else
+  echo "Fetching latest successful run of $WORKFLOW_FILE..."
+  RUN_ID=$(api_get "$API_BASE/repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?status=success&per_page=1" \
+    | python3 -c "import sys,json; runs=json.load(sys.stdin)['workflow_runs']; print(runs[0]['id']) if runs else (print('No successful runs found', file=sys.stderr) or exit(1))")
+  echo "Latest successful run ID: $RUN_ID"
+fi
+
+echo "Fetching artifact list for run $RUN_ID..."
+ARTIFACT_URL=$(api_get "$API_BASE/repos/$REPO/actions/runs/$RUN_ID/artifacts" \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+artifacts = [a for a in data['artifacts'] if a['name'] == '$ARTIFACT_NAME']
+if not artifacts:
+    print('Artifact \"$ARTIFACT_NAME\" not found in run $RUN_ID', file=sys.stderr)
+    exit(1)
+print(artifacts[0]['archive_download_url'])
+")
+
+echo "Downloading artifact: $ARTIFACT_NAME"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+api_get "$ARTIFACT_URL" -L -o "$TMPDIR/artifact.zip"
+
+echo "Extracting to $DIST_DIR..."
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+unzip -q "$TMPDIR/artifact.zip" -d "$DIST_DIR"
+
+echo "Done. Artifact extracted to $DIST_DIR"


### PR DESCRIPTION
## 概要

GitHub Actions の `front.yml` ワークフローがアップロードするビルド成果物（`build-artifacts`）を `front/dist` にデプロイするシェルスクリプトを追加します。

## 追加ファイル

`front/scripts/download-artifacts.sh`

## 使い方

```bash
# 最新の成功した実行の成果物を使う
./front/scripts/download-artifacts.sh

# run ID を指定して特定の実行の成果物を使う
./front/scripts/download-artifacts.sh 1234567
```

## 主な仕様

- GitHub REST API へのアクセスに `~/.secrets/goduploader-graphql-deploy` のFine-grainedトークンを使用（トークンはログに出力されない）
- JSONの処理には `jq` を使用
- デプロイはシンボリックリンクのアトミックスワップで行う
  - `front/dist.new` に展開後、`mv -T`（`rename(2)` syscall）で `dist` をアトミックに差し替えるため、デプロイ中にファイルが消える瞬間が生じない
  - 初回実行時に `dist` が実ディレクトリの場合は退避してからスワップする

---
_Generated by [Claude Code](https://claude.ai/code/session_019nVyW1nr4Bfx3emnrYxnbx)_