### PR TITLE
フロントエンドのデプロイ先ディレクトリにタイムスタンプを付与する

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -13,6 +13,8 @@
 /_app
 /_app_k8s
 /.react-router
+/dist/
+/dist.*/
 
 # misc
 .DS_Store

--- a/front/scripts/download-artifacts.sh
+++ b/front/scripts/download-artifacts.sh
@@ -55,30 +55,21 @@ api_get "$ARTIFACT_URL" -L -o "$TMPDIR/artifact.zip"
 
 DIST_PARENT="$(dirname "$DIST_DIR")"
 DIST_NAME="$(basename "$DIST_DIR")"
-NEW_DIST="$DIST_PARENT/${DIST_NAME}.new"
+TIMESTAMP="$(date +%Y%m%d%H%M%S)"
+NEW_DIST="$DIST_PARENT/${DIST_NAME}.${TIMESTAMP}"
 
 echo "Extracting to $NEW_DIST..."
-rm -rf "$NEW_DIST"
 mkdir -p "$NEW_DIST"
 unzip -q "$TMPDIR/artifact.zip" -d "$NEW_DIST"
 
-# Record the current symlink target (if any) so we can clean it up after the swap
-OLD_LINK_TARGET=""
-if [[ -L "$DIST_DIR" ]]; then
-  OLD_LINK_TARGET="$(readlink "$DIST_DIR")"
-  [[ "$OLD_LINK_TARGET" != /* ]] && OLD_LINK_TARGET="$DIST_PARENT/$OLD_LINK_TARGET"
-elif [[ -d "$DIST_DIR" ]]; then
+if [[ -d "$DIST_DIR" && ! -L "$DIST_DIR" ]]; then
   # First run: dist is a real directory; move it aside before swapping
-  mv "$DIST_DIR" "$DIST_PARENT/${DIST_NAME}.old"
-  OLD_LINK_TARGET="$DIST_PARENT/${DIST_NAME}.old"
+  mv "$DIST_DIR" "$DIST_PARENT/${DIST_NAME}.$(date -r "$DIST_DIR" +%Y%m%d%H%M%S 2>/dev/null || echo old)"
 fi
 
 # Atomically replace the symlink via rename(2): ln creates a temp symlink,
 # mv -T renames it over dist in a single syscall so dist is never absent
-ln -sfn "${DIST_NAME}.new" "$DIST_PARENT/${DIST_NAME}.tmp"
+ln -sfn "${DIST_NAME}.${TIMESTAMP}" "$DIST_PARENT/${DIST_NAME}.tmp"
 mv -T "$DIST_PARENT/${DIST_NAME}.tmp" "$DIST_DIR"
 
-# Clean up the previous content now that the swap is complete
-[[ -n "$OLD_LINK_TARGET" ]] && rm -rf "$OLD_LINK_TARGET"
-
-echo "Done. Artifact deployed to $DIST_DIR"
+echo "Done. Artifact deployed to $DIST_DIR -> ${DIST_NAME}.${TIMESTAMP}"


### PR DESCRIPTION
## 概要

フロントエンドのデプロイスクリプト (`front/scripts/download-artifacts.sh`) の挙動を変更し、artifactの展開先ディレクトリ名にタイムスタンプを付与するようにしました。

## 変更内容

### `front/scripts/download-artifacts.sh`

- artifact の展開先ディレクトリ名を `dist.new` から `dist.YYYYMMDDHHMMSS` 形式に変更
  - いつデプロイされた成果物かが一目で分かるようになります
- `dist` シンボリックリンクの向き先を新しいタイムスタンプ付きディレクトリに更新
- 旧バージョンのディレクトリは削除せず残すようにしました（デプロイ履歴として参照可能）
- 初回実行時に `dist` が実ディレクトリだった場合も、タイムスタンプ付きにリネームして保持します

### `front/.gitignore`

- `/dist/` および `/dist.*/` を追加
  - `dist` シンボリックリンク本体と、タイムスタンプ付き展開ディレクトリがすべて無視されるようになります

## 動作イメージ

```
front/
├── dist -> dist.20260517153000   # シンボリックリンク（最新を指す）
├── dist.20260517153000/          # 最新のartifact
└── dist.20260510120000/          # 以前のartifact（残存）
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJifW4vaTuMSj6xEJ21fWP)_