### PR TITLE
Add script to download frontend build artifacts from GitHub Actions

### DIFF
--- a/front/scripts/download-artifacts.sh
+++ b/front/scripts/download-artifacts.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="kmc-jp/goduploader-graphql"
+WORKFLOW_FILE="front.yml"
+ARTIFACT_NAME="build-artifacts"
+DIST_DIR="$(cd "$(dirname "$0")/../dist" && pwd)"
+TOKEN_FILE="$HOME/.secrets/goduploader-graphql-deploy"
+
+if [ ! -f "$TOKEN_FILE" ]; then
+  echo "Error: Token file not found: $TOKEN_FILE" >&2
+  exit 1
+fi
+
+api() {
+  curl -fsSL \
+    -H "Authorization: Bearer $(cat "$TOKEN_FILE")" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$@"
+}
+
+if [ $# -ge 1 ]; then
+  RUN_ID="$1"
+else
+  echo "Looking up latest successful run of $WORKFLOW_FILE on main..."
+  RUN_ID=$(api "https://api.github.com/repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?branch=main&status=success&per_page=1" \
+    | python3 -c "import sys,json; runs=json.load(sys.stdin)['workflow_runs']; print(runs[0]['id']) if runs else exit(1)")
+  echo "Using run ID: $RUN_ID"
+fi
+
+ARTIFACT_URL=$(api "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/artifacts" \
+  | python3 -c "
+import sys, json
+arts = json.load(sys.stdin)['artifacts']
+match = [a for a in arts if a['name'] == '$ARTIFACT_NAME']
+if not match:
+    print('Artifact \"$ARTIFACT_NAME\" not found in run $RUN_ID', file=sys.stderr)
+    exit(1)
+print(match[0]['archive_download_url'])
+")
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Downloading artifact..."
+api -L -o "$TMPDIR/artifact.zip" "$ARTIFACT_URL"
+
+echo "Extracting..."
+unzip -q "$TMPDIR/artifact.zip" -d "$TMPDIR/extracted"
+
+mkdir -p "$DIST_DIR"
+echo "Syncing to $DIST_DIR..."
+rsync -a --delete "$TMPDIR/extracted/" "$DIST_DIR/"
+
+echo "Done."

--- a/front/scripts/download-artifacts.sh
+++ b/front/scripts/download-artifacts.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REPO="kmc-jp/goduploader-graphql"
 WORKFLOW_FILE="front.yml"
 ARTIFACT_NAME="build-artifacts"
-DIST_DIR="$(cd "$(dirname "$0")/../dist" && pwd)"
+DIST_DIR="$(realpath "$(dirname "$0")/..")/dist"
 TOKEN_FILE="$HOME/.secrets/goduploader-graphql-deploy"
 
 if [ ! -f "$TOKEN_FILE" ]; then


### PR DESCRIPTION
## Summary
This PR adds a new bash script that automates downloading and syncing frontend build artifacts from GitHub Actions workflows to the local `dist` directory.

## Key Changes
- **New script**: `front/scripts/download-artifacts.sh` - A utility script that:
  - Authenticates with GitHub API using a stored token
  - Automatically finds the latest successful run of the `front.yml` workflow on the main branch (or accepts a specific run ID as an argument)
  - Downloads the `build-artifacts` artifact from the identified workflow run
  - Extracts the artifact and syncs it to the local `dist` directory using rsync
  - Includes proper error handling and cleanup of temporary files

## Implementation Details
- Uses GitHub API v2022-11-28 for authentication and artifact retrieval
- Expects a GitHub token to be stored at `~/.secrets/goduploader-graphql-deploy`
- Leverages Python's JSON parsing for extracting artifact metadata from API responses
- Implements safe bash practices with `set -euo pipefail` and trap-based cleanup
- Supports both automatic (latest successful run) and manual (specific run ID) artifact retrieval modes

https://claude.ai/code/session_019XRQfXftmx1zJuqnH2ULLz