### PR TITLE
Exclude MSW from production builds and dev-only initialization

### DIFF
--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -9,7 +9,7 @@ import { App } from "./App";
 import RelayEnvironment from "./RelayEnvironment";
 
 async function enableMocking() {
-  if (import.meta.env.VITE_USE_MSW !== "1") return;
+  if (!import.meta.env.DEV || import.meta.env.VITE_USE_MSW !== "1") return;
   const { worker } = await import("./mocks/browser");
   return worker.start({ onUnhandledRequest: "warn" });
 }

--- a/front/vite.config.mts
+++ b/front/vite.config.mts
@@ -1,12 +1,33 @@
 /// <reference types="vitest/config" />
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import relay from "vite-plugin-relay";
 
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), nodePolyfills({ protocolImports: true }), relay],
+  plugins: [
+    react(),
+    nodePolyfills({ protocolImports: true }),
+    relay,
+    {
+      name: "exclude-msw-from-build",
+      apply: "build",
+      closeBundle() {
+        const distDir = path.resolve(__dirname, "dist");
+        fs.rmSync(path.join(distDir, "mockServiceWorker.js"), { force: true });
+        fs.rmSync(path.join(distDir, "mocks"), {
+          recursive: true,
+          force: true,
+        });
+      },
+    },
+  ],
   server: {
     proxy: {
       "/api": "http://localhost:5000",


### PR DESCRIPTION
## Summary
This PR prevents Mock Service Worker (MSW) from being included in production builds and ensures MSW is only initialized during development.

## Key Changes
- **Vite Config**: Added a custom Vite plugin that removes MSW artifacts (`mockServiceWorker.js` and `mocks/` directory) from the production build output
- **MSW Initialization**: Updated the MSW enablement check to only initialize when in development mode (`import.meta.env.DEV`), in addition to the existing `VITE_USE_MSW` flag check

## Implementation Details
- The custom Vite plugin uses the `closeBundle` hook to clean up MSW files after the build is complete, ensuring they don't ship to production
- The MSW initialization now requires both development mode AND the explicit `VITE_USE_MSW=1` flag, providing an extra safety layer to prevent accidental MSW usage in production
- Uses Node.js built-in modules (`fs`, `path`, `url`) for file operations and path resolution

https://claude.ai/code/session_01PXMTX8vGxQ8SqoyL2J9W6u