### PR TITLE
デプロイにghtknを使う

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ hatsuneで ~passenger/GodUploader-graphql/front/deploy.sh を実行すると、G
 
 deploy.shの引数としてrun IDを渡すと、当該runの成果物を使ってデプロイを行うため、ロールバックなどに使えます。
 
+GitHub Actionsの実行結果や成果物を取得する際に使う認証情報の管理に [ghtkn](https://github.com/suzuki-shunsuke/ghtkn) を使っています。
+
 ### DBのマイグレーションを行う
 
 https://github.com/sqldef/sqldef からsqlite3defをインストールしておいてください。

--- a/front/scripts/deploy.sh
+++ b/front/scripts/deploy.sh
@@ -5,16 +5,10 @@ REPO="kmc-jp/goduploader-graphql"
 WORKFLOW_FILE="front.yml"
 ARTIFACT_NAME="build-artifacts"
 DIST_DIR="$(realpath "$(dirname "$0")/..")/dist"
-TOKEN_FILE="$HOME/.secrets/goduploader-graphql-deploy"
-
-if [ ! -f "$TOKEN_FILE" ]; then
-  echo "Error: Token file not found: $TOKEN_FILE" >&2
-  exit 1
-fi
 
 api() {
   curl -fsSL \
-    -H "Authorization: Bearer $(cat "$TOKEN_FILE")" \
+    -H "Authorization: Bearer $(ghtkn get)" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2026-03-10" \
     "$@"

--- a/ghtkn.yaml
+++ b/ghtkn.yaml
@@ -1,0 +1,3 @@
+apps:
+  - name: kmc-jp/goduploader-graphql-deploy
+    client_id: Iv23liAVKe614ZUwJS4I


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/ghtkn
- [ghtkn でローカル開発用に GitHub Access Token をセキュアに生成して PAT から卒業する](https://zenn.dev/shunsuke_suzuki/articles/ghtkn-secure-github-token)