### PR TITLE
Replace ghtkn with OAuth2 Device Flow for GitHub authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ hatsuneで ~passenger/GodUploader-graphql/front/deploy.sh を実行すると、G
 
 deploy.shの引数としてrun IDを渡すと、当該runの成果物を使ってデプロイを行うため、ロールバックなどに使えます。
 
-GitHub Actionsの実行結果や成果物を取得する際に使う認証情報の管理に [ghtkn](https://github.com/suzuki-shunsuke/ghtkn) を使っています。
+deploy.shはGitHub APIへのアクセスに必要なトークンを [OAuth2 Device Flow](https://docs.github.com/ja/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow) で取得します。スクリプトを実行すると認証用のURLとコードが表示されるので、ブラウザでURLを開いてコードを入力し、GitHubアカウントでアプリを認証してください。認証完了後にEnterキーを押すとデプロイが続行されます。
 
 ### DBのマイグレーションを行う
 

--- a/front/scripts/deploy.sh
+++ b/front/scripts/deploy.sh
@@ -6,6 +6,7 @@ WORKFLOW_FILE="front.yml"
 ARTIFACT_NAME="build-artifacts"
 DIST_DIR="$(realpath "$(dirname "$0")/..")/dist"
 
+# https://github.com/organizations/kmc-jp/settings/apps/goduploader-graphql-deploy
 CLIENT_ID="Iv23liAVKe614ZUwJS4I"
 
 get_github_token() {

--- a/front/scripts/deploy.sh
+++ b/front/scripts/deploy.sh
@@ -6,9 +6,74 @@ WORKFLOW_FILE="front.yml"
 ARTIFACT_NAME="build-artifacts"
 DIST_DIR="$(realpath "$(dirname "$0")/..")/dist"
 
+CLIENT_ID="Iv23liAVKe614ZUwJS4I"
+
+get_github_token() {
+  local client_id="$1"
+
+  local device_response
+  device_response=$(curl -fsSL \
+    -X POST \
+    -H "Accept: application/json" \
+    --data-urlencode "client_id=$client_id" \
+    --data-urlencode "scope=repo" \
+    "https://github.com/login/device/code")
+
+  local device_code user_code interval expires_in
+  device_code=$(echo "$device_response" | jq -r '.device_code')
+  user_code=$(echo "$device_response"   | jq -r '.user_code')
+  interval=$(echo "$device_response"    | jq -r '.interval // 5')
+  expires_in=$(echo "$device_response"  | jq -r '.expires_in // 900')
+
+  echo "以下のURLをブラウザで開き、コードを入力してください:" >&2
+  echo "  URL:  https://github.com/login/device" >&2
+  echo "  Code: $user_code" >&2
+  read -rp "ログイン完了したらEnterキーを押してください..." >&2
+
+  local start_time=$SECONDS
+  while true; do
+    if (( SECONDS - start_time >= expires_in )); then
+      echo "Device flow timed out." >&2
+      return 1
+    fi
+
+    sleep "$interval"
+
+    local token_response error access_token
+    token_response=$(curl -fsSL \
+      -X POST \
+      -H "Accept: application/json" \
+      --data-urlencode "client_id=$client_id" \
+      --data-urlencode "device_code=$device_code" \
+      --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+      "https://github.com/login/oauth/access_token")
+
+    error=$(echo "$token_response" | jq -r '.error // ""')
+
+    case "$error" in
+      "")
+        access_token=$(echo "$token_response" | jq -r '.access_token')
+        echo "$access_token"
+        return 0
+        ;;
+      "authorization_pending")
+        ;;
+      "slow_down")
+        interval=$((interval + 5))
+        ;;
+      *)
+        echo "Authorization failed: $error" >&2
+        return 1
+        ;;
+    esac
+  done
+}
+
+GITHUB_TOKEN=$(get_github_token "$CLIENT_ID")
+
 api() {
   curl -fsSL \
-    -H "Authorization: Bearer $(ghtkn get -c $(realpath "$(dirname "$0")/../..")/ghtkn.yaml)" \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2026-03-10" \
     "$@"
@@ -19,20 +84,13 @@ if [ $# -ge 1 ]; then
 else
   echo "Looking up latest successful run of $WORKFLOW_FILE on main..."
   RUN_ID=$(api "https://api.github.com/repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?branch=main&status=success&per_page=1" \
-    | python3 -c "import sys,json; runs=json.load(sys.stdin)['workflow_runs']; print(runs[0]['id']) if runs else exit(1)")
+    | jq -r 'if (.workflow_runs | length) > 0 then .workflow_runs[0].id else error("no successful runs found") end')
   echo "Using run ID: $RUN_ID"
 fi
 
 ARTIFACT_URL=$(api "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/artifacts" \
-  | python3 -c "
-import sys, json
-arts = json.load(sys.stdin)['artifacts']
-match = [a for a in arts if a['name'] == '$ARTIFACT_NAME']
-if not match:
-    print('Artifact \"$ARTIFACT_NAME\" not found in run $RUN_ID', file=sys.stderr)
-    exit(1)
-print(match[0]['archive_download_url'])
-")
+  | jq -r --arg name "$ARTIFACT_NAME" \
+    '.artifacts | map(select(.name == $name)) | if length > 0 then .[0].archive_download_url else error("Artifact \($name) not found") end')
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/ghtkn.yaml
+++ b/ghtkn.yaml
@@ -1,3 +1,0 @@
-apps:
-  - name: kmc-jp/goduploader-graphql-deploy
-    client_id: Iv23liAVKe614ZUwJS4I


### PR DESCRIPTION
## Summary
Replaced the external `ghtkn` dependency with a built-in OAuth2 Device Flow implementation for GitHub API authentication in the deployment script. This eliminates the need for external tools and simplifies the authentication process.

## Key Changes
- **Removed external dependency**: Deleted `ghtkn.yaml` configuration file and removed `ghtkn` CLI invocation from the authentication flow
- **Implemented OAuth2 Device Flow**: Added `get_github_token()` function that handles GitHub's device flow authentication:
  - Initiates device code request with hardcoded client ID
  - Displays authentication URL and user code to the user
  - Polls GitHub's token endpoint until authorization is complete or times out
  - Handles error cases including `authorization_pending`, `slow_down`, and other errors
- **Updated API calls**: Modified the `api()` function to use the newly obtained `GITHUB_TOKEN` instead of calling `ghtkn`
- **Replaced Python with jq**: Converted JSON parsing from Python one-liners to `jq` for better maintainability:
  - Workflow run lookup now uses `jq` with proper error handling
  - Artifact URL extraction now uses `jq` with variable interpolation
- **Updated documentation**: Modified README to explain the new OAuth2 Device Flow authentication process and removed references to `ghtkn`

## Implementation Details
- The device flow implementation includes proper timeout handling (default 900 seconds) and respects the server-specified polling interval
- User-friendly Japanese prompts guide the user through the authentication process
- Error messages are written to stderr while tokens are written to stdout, maintaining proper stream separation
- The implementation uses standard curl and jq utilities, reducing external dependencies

https://claude.ai/code/session_01DZmgPejLX9Tq6gH7Xgg7ba