### PR TITLE
fix: WebP変換をlossless圧縮に変更してピクセルアートの劣化を防ぐ

### DIFF
--- a/api/src/goduploader/image/webp.py
+++ b/api/src/goduploader/image/webp.py
@@ -14,7 +14,7 @@ def _is_gif(illust_path: str):
 
 def _generate_normal_webp(illust_path, webp_path):
     with Image.open(illust_path) as img:
-        img.save(webp_path, format=None, quality=80)
+        img.save(webp_path, format="webp", lossless=True)
 
 
 def _generate_animated_webp(illust_path, webp_path):
@@ -33,7 +33,7 @@ def _generate_animated_webp(illust_path, webp_path):
             format="webp",
             save_all=True,
             append_images=frames[1:],
-            quality=80,
+            lossless=True,
             duration=durations,
             loop=img.info.get("loop", 0),
         )


### PR DESCRIPTION
## 概要

closes #407

ピクセルアート/ドット絵をアップロードした際、WebP変換にlossy圧縮（VP8, quality=80）が使われていたため、ピクセルの境界がぼやけて正しく表示されない問題があった。

Issue #407 の「案1: すべてLossless圧縮にしてしまう」の方針に従い、静止画・アニメーションGIF両方のWebP変換をlossless圧縮（VP8L）に変更した。

## 変更内容

`api/src/goduploader/image/webp.py` の2箇所を変更。

- `_generate_normal_webp`: `format=None, quality=80` → `format="webp", lossless=True`
- `_generate_animated_webp`: `quality=80` → `lossless=True`

## 影響範囲

- 新規アップロード分のWebPがlossless（VP8L）で生成されるようになる
- 既存のWebPファイルには影響しない
- ファイルサイズはlosslessの方が若干大きくなる場合があるが、元のPNG/JPEG と比べて十分小さい

## 検証

WebPバイナリヘッダーで `VP8L`（lossless）になっていることを確認済み。

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkGJts2oQDCriMPZGRUmge)_